### PR TITLE
refactor: replace SCRIPT_USAGE with SCRIPT_COMMANDS array

### DIFF
--- a/.devcontainer/additions/addition-templates/README-additions-template.md
+++ b/.devcontainer/additions/addition-templates/README-additions-template.md
@@ -83,14 +83,14 @@ Addition scripts are bash scripts that automate the installation of tools, confi
 
 **Characteristics:**
 - Non-interactive (flag-based interface)
-- Multiple commands in single script via COMMANDS array
+- Multiple commands in single script via SCRIPT_COMMANDS array
 - Integrates with dev-setup menu (shows all commands)
-- Help text auto-generated from COMMANDS array
+- Help text auto-generated from SCRIPT_COMMANDS array
 - Supports both direct CLI usage and menu execution
 - Dynamic argument parsing via cmd-framework.sh
 
 **Key Features:**
-- **Single Source of Truth:** COMMANDS array defines all commands (no manual duplication)
+- **Single Source of Truth:** SCRIPT_COMMANDS array defines all commands (no manual duplication)
 - **Auto-discovery:** Metadata enables automatic menu integration
 - **Prerequisites:** Can require config scripts before execution
 - **Reusable:** Uses cmd-framework.sh and utilities.sh libraries
@@ -160,9 +160,9 @@ cp /workspace/.devcontainer/additions/addition-templates/_template-cmd-script.sh
 # - Update CMD_SCRIPT_NAME, CMD_SCRIPT_DESCRIPTION, CMD_SCRIPT_CATEGORY
 # - Update CMD_PREREQUISITE_CONFIGS (or leave empty if none)
 
-# 3. Define your COMMANDS array
+# 3. Define your SCRIPT_COMMANDS array
 # Format: "category|flag|description|function|requires_arg|param_prompt"
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Management|--list|List all items|cmd_list|false|"
     "Management|--delete|Delete an item|cmd_delete|true|Enter item ID"
     "Analysis|--stats|Show statistics|cmd_stats|false|"
@@ -193,7 +193,7 @@ dev-setup
 ```
 
 **Benefits:**
-- Add new command = 1 line in COMMANDS array + implement function
+- Add new command = 1 line in SCRIPT_COMMANDS array + implement function
 - Help text auto-generated
 - Menu integration automatic
 - No need to modify parse_args()
@@ -286,7 +286,7 @@ Complete template for creating command scripts with automatic menu integration.
 
 **Includes:**
 - Metadata fields (CMD_SCRIPT_NAME, CMD_SCRIPT_DESCRIPTION, CMD_SCRIPT_CATEGORY, CMD_PREREQUISITE_CONFIGS)
-- COMMANDS array pattern (single source of truth for all commands)
+- SCRIPT_COMMANDS array pattern (single source of truth for all commands)
 - cmd-framework.sh integration (automatic argument parsing and help generation)
 - utilities.sh integration (date ranges, currency formatting, number formatting)
 - Example command implementations (management, analysis, testing)
@@ -301,9 +301,9 @@ CMD_SCRIPT_DESCRIPTION="Manage and analyze example resources"
 CMD_SCRIPT_CATEGORY="UNCATEGORIZED"
 CMD_PREREQUISITE_CONFIGS="config-example.sh"  # Optional
 
-# COMMANDS array (6 fields)
+# SCRIPT_COMMANDS array (6 fields)
 # Format: category|flag|description|function|requires_arg|param_prompt
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Management|--list|List all items|cmd_list|false|"
     "Management|--delete|Delete an item|cmd_delete|true|Enter item ID"
     "Analysis|--stats|Show statistics|cmd_stats|false|"
@@ -322,17 +322,17 @@ cmd_delete() {
 # Help and parsing (uses framework)
 show_help() {
     source "${SCRIPT_DIR}/lib/cmd-framework.sh"
-    cmd_framework_generate_help COMMANDS "cmd-example.sh"
+    cmd_framework_generate_help SCRIPT_COMMANDS "cmd-example.sh"
 }
 
 parse_args() {
     source "${SCRIPT_DIR}/lib/cmd-framework.sh"
-    cmd_framework_parse_args COMMANDS "cmd-example.sh" "$@"
+    cmd_framework_parse_args SCRIPT_COMMANDS "cmd-example.sh" "$@"
 }
 ```
 
 **Adding a new command:**
-1. Add one line to COMMANDS array
+1. Add one line to SCRIPT_COMMANDS array
 2. Implement the function
 3. Done! (Help text, menu integration, parsing all automatic)
 
@@ -381,9 +381,9 @@ parse_args() {
 | `CMD_SCRIPT_DESCRIPTION` | Yes | Brief description (one sentence) | `"Manage AI models, spending, and usage"` |
 | `CMD_SCRIPT_CATEGORY` | Yes | Category for menu organization | `"AI_TOOLS"` |
 | `CMD_PREREQUISITE_CONFIGS` | No | Space-separated config scripts | `"config-ai-claudecode.sh"` or `""` |
-| `COMMANDS` | Yes | Array of command definitions | See COMMANDS array format below |
+| `SCRIPT_COMMANDS` | Yes | Array of command definitions | See SCRIPT_COMMANDS array format below |
 
-**COMMANDS Array Format (6 fields):**
+**SCRIPT_COMMANDS Array Format (6 fields):**
 ```
 "category|flag|description|function|requires_arg|param_prompt"
 ```
@@ -399,7 +399,7 @@ parse_args() {
 
 **Example:**
 ```bash
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Management|--list|List all items|cmd_list|false|"
     "Management|--delete|Delete an item|cmd_delete|true|Enter item ID"
 )

--- a/.devcontainer/additions/addition-templates/README-service-template.md
+++ b/.devcontainer/additions/addition-templates/README-service-template.md
@@ -13,7 +13,7 @@ This template helps you create **service-*.sh** scripts that manage long-running
 3. [Quick Start](#quick-start)
 4. [Template Structure](#template-structure)
 5. [Metadata Fields](#metadata-fields)
-6. [COMMANDS Array](#commands-array)
+6. [SCRIPT_COMMANDS Array](#commands-array)
 7. [Core Functions](#core-functions)
 8. [Supervisord Integration](#supervisord-integration)
 9. [Helper Functions](#helper-functions)
@@ -60,8 +60,8 @@ service-nginx.sh   ← All operations: start, stop, restart, status, logs, valid
 |--------|------------------------------|-------------------------|
 | **Files** | 2 files per service | 1 file per service |
 | **Operations** | 2 ops (start, stop) | 10+ ops (start, stop, restart, status, logs, validate, reload, etc.) |
-| **Help text** | Manual duplication | Auto-generated from COMMANDS array |
-| **Extensibility** | Add new script for each op | Add 1 line to COMMANDS array |
+| **Help text** | Manual duplication | Auto-generated from SCRIPT_COMMANDS array |
+| **Extensibility** | Add new script for each op | Add 1 line to SCRIPT_COMMANDS array |
 | **Discovery** | Only start-*.sh discovered | Full service-*.sh discovery |
 | **Naming clarity** | Ambiguous (install vs start?) | Clear (cmd vs service) |
 | **Framework reuse** | Custom parsing | Uses cmd-framework.sh |
@@ -115,10 +115,10 @@ SERVICE_SCRIPT_CATEGORY="INFRA_CONFIG"
 SERVICE_PREREQUISITE_CONFIGS=""  # Or "config-myservice.sh"
 ```
 
-### 3. Define COMMANDS Array
+### 3. Define SCRIPT_COMMANDS Array
 
 ```bash
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Control|--start|Start service in foreground|service_start|false|"
     "Control|--stop|Stop service gracefully|service_stop|false|"
     "Control|--restart|Restart service|service_restart|false|"
@@ -182,10 +182,10 @@ SERVICE_SCRIPT_CATEGORY="INFRA_CONFIG"
 SERVICE_PREREQUISITE_CONFIGS=""
 ```
 
-### 2. COMMANDS Array (Lines 22-40)
+### 2. SCRIPT_COMMANDS Array (Lines 22-40)
 
 ```bash
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Control|--start|Start service|service_start|false|"
     "Control|--stop|Stop service|service_stop|false|"
     # ... 11 total commands
@@ -345,9 +345,9 @@ SERVICE_AUTO_RESTART="false"  # Don't restart
 
 ---
 
-## COMMANDS Array
+## SCRIPT_COMMANDS Array
 
-The COMMANDS array is the **single source of truth** for all service operations. Each line defines one command.
+The SCRIPT_COMMANDS array is the **single source of truth** for all service operations. Each line defines one command.
 
 ### Format (6 fields, pipe-separated)
 
@@ -398,7 +398,7 @@ The COMMANDS array is the **single source of truth** for all service operations.
 ### Example with Parameter
 
 ```bash
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Config|--set-port|Change service port|service_set_port|true|Enter port number (1-65535)"
 )
 
@@ -970,7 +970,7 @@ SERVICE_SCRIPT_DESCRIPTION="Simple HTTP server for development"
 SERVICE_SCRIPT_CATEGORY="INFRA_CONFIG"
 SERVICE_PREREQUISITE_CONFIGS=""
 
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Control|--start|Start web server in foreground|service_start|false|"
     "Control|--stop|Stop web server|service_stop|false|"
     "Control|--restart|Restart web server|service_restart|false|"
@@ -1018,7 +1018,7 @@ SERVICE_SCRIPT_DESCRIPTION="PostgreSQL database server"
 SERVICE_SCRIPT_CATEGORY="DATABASE"
 SERVICE_PREREQUISITE_CONFIGS="config-database.sh"
 
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Control|--start|Start database|service_start|false|"
     "Control|--stop|Stop database|service_stop|false|"
     "Control|--restart|Restart database|service_restart|false|"
@@ -1134,7 +1134,7 @@ service_stop() {
 This is where the extensibility shines! Add operations that weren't possible before:
 
 ```bash
-COMMANDS=(
+SCRIPT_COMMANDS=(
     # Migrated from start/stop
     "Control|--start|Start service|service_start|false|"
     "Control|--stop|Stop service|service_stop|false|"
@@ -1303,7 +1303,7 @@ bash /workspace/.devcontainer/additions/config-supervisor.sh
 The **service-*.sh** pattern provides:
 
 ✅ **Consolidation** - 1 file instead of 2
-✅ **Extensibility** - Add operations by adding 1 line to COMMANDS array
+✅ **Extensibility** - Add operations by adding 1 line to SCRIPT_COMMANDS array
 ✅ **Framework reuse** - Uses cmd-framework.sh for parsing and help
 ✅ **Rich operations** - From 2 ops to 10+ ops per service
 ✅ **Supervisord compatibility** - Works with auto-start via exec
@@ -1313,7 +1313,7 @@ The **service-*.sh** pattern provides:
 **Next steps:**
 1. Copy `_template-service-script.sh`
 2. Update metadata
-3. Define COMMANDS array
+3. Define SCRIPT_COMMANDS array
 4. Implement operations
 5. Test thoroughly
 6. Enable auto-start

--- a/.devcontainer/additions/addition-templates/_template-cmd-script.sh
+++ b/.devcontainer/additions/addition-templates/_template-cmd-script.sh
@@ -12,7 +12,7 @@
 #
 # Command scripts should:
 #   - Provide multiple related commands via flags
-#   - Use COMMANDS array as single source of truth
+#   - Use SCRIPT_COMMANDS array as single source of truth
 #   - Be non-interactive (use flags, not menus)
 #   - Provide clear, actionable output
 #   - Support both direct execution and menu integration
@@ -44,10 +44,10 @@
 # For more details, see: .devcontainer/additions/README-additions.md
 #
 #------------------------------------------------------------------------------
-# COMMANDS ARRAY PATTERN - Single source of truth for all commands
+# SCRIPT_COMMANDS ARRAY PATTERN - Single source of truth for all commands
 #------------------------------------------------------------------------------
 #
-# The COMMANDS array defines all available commands. Each entry has 6 fields:
+# The SCRIPT_COMMANDS array defines all available commands. Each entry has 6 fields:
 #
 # Format: "category|flag|description|function|requires_arg|param_prompt"
 #
@@ -63,7 +63,7 @@
 #   "Management|--delete|Delete an item|cmd_delete|true|Enter item ID"
 #   "Analysis|--stats|Show statistics|cmd_stats|false|"
 #
-# Benefits of COMMANDS array:
+# Benefits of SCRIPT_COMMANDS array:
 #   - Add new command = just 1 line + implement function
 #   - Help text auto-generated
 #   - Menu integration automatic
@@ -79,11 +79,11 @@ SCRIPT_CATEGORY="UNCATEGORIZED"
 SCRIPT_PREREQUISITES=""  # Example: "config-example.sh" or "" if none
 
 #------------------------------------------------------------------------------
-# COMMAND DEFINITIONS - Single source of truth
+# SCRIPT_COMMANDS DEFINITIONS - Single source of truth
 #------------------------------------------------------------------------------
 
 # Format: category|flag|description|function|requires_arg|param_prompt
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Management|--list|List all items|cmd_list|false|"
     "Management|--show|Show details for specific item|cmd_show|true|Enter item ID"
     "Management|--create|Create new item|cmd_create|true|Enter item name"
@@ -385,8 +385,8 @@ show_help() {
         source "${SCRIPT_DIR}/lib/cmd-framework.sh"
     fi
 
-    # Generate help from COMMANDS array (pass version as 3rd argument)
-    cmd_framework_generate_help COMMANDS "cmd-example.sh" "$SCRIPT_VER"
+    # Generate help from SCRIPT_COMMANDS array (pass version as 3rd argument)
+    cmd_framework_generate_help SCRIPT_COMMANDS "cmd-example.sh" "$SCRIPT_VER"
 
     # Add examples section
     echo ""
@@ -406,7 +406,7 @@ parse_args() {
     fi
 
     # Use framework to parse arguments
-    cmd_framework_parse_args COMMANDS "cmd-example.sh" "$@"
+    cmd_framework_parse_args SCRIPT_COMMANDS "cmd-example.sh" "$@"
 }
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/additions/addition-templates/_template-install-script.sh
+++ b/.devcontainer/additions/addition-templates/_template-install-script.sh
@@ -105,10 +105,39 @@ SCRIPT_DESCRIPTION="[Brief description of what this script installs and its purp
 SCRIPT_CATEGORY="DEV_TOOLS"  # Options: DEV_TOOLS, INFRA_CONFIG, AI_TOOLS, MONITORING, DATABASE, CLOUD
 SCRIPT_CHECK_COMMAND="command -v [tool-name] >/dev/null 2>&1"  # Command to check if already installed
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall"
+#------------------------------------------------------------------------------
+# SCRIPT_COMMANDS ARRAY - For dev-setup.sh menu integration
+#------------------------------------------------------------------------------
+# Define available actions for this install script. These appear in the
+# dev-setup.sh submenu when user selects this tool.
+#
+# Format: category|flag|description|function|requires_arg|param_prompt
+#
+# This is the SAME format used by cmd-*.sh scripts for consistency.
+#
+# Fields:
+#   category     - Menu grouping (e.g., "Action", "Info")
+#   flag         - Command line flag (empty = default action, run with no args)
+#   description  - User-friendly text for menus
+#   function     - Not used for install scripts (leave empty)
+#   requires_arg - "true" if flag needs a parameter, "false" otherwise
+#   param_prompt - Prompt text if parameter needed (empty if no parameter)
+#
+# Standard commands for most install scripts:
+SCRIPT_COMMANDS=(
+    "Action||Install this tool||false|"
+    "Action|--uninstall|Uninstall this tool||false|"
+    "Info|--help|Show help and usage information||false|"
+)
+#
+# Extended example with version support (for scripts that support --version):
+# SCRIPT_COMMANDS=(
+#     "Action||Install with default version||false|"
+#     "Action|--version|Install specific version||true|Enter version (e.g., 1.21.0)"
+#     "Action|--uninstall|Uninstall this tool||false|"
+#     "Info|--help|Show help and usage information||false|"
+# )
+#------------------------------------------------------------------------------
 
 # Optional: Prerequisite configurations required before installation
 # Uncomment and modify if your tool requires specific configurations

--- a/.devcontainer/additions/addition-templates/_template-service-script.sh
+++ b/.devcontainer/additions/addition-templates/_template-service-script.sh
@@ -15,7 +15,7 @@
 # Service scripts should:
 #   - Manage long-running background services
 #   - Provide multiple operations via flags (start, stop, restart, status, logs, validate)
-#   - Use COMMANDS array as single source of truth
+#   - Use SCRIPT_COMMANDS array as single source of truth
 #   - Be non-interactive (use flags, not menus)
 #   - Integrate with supervisord for auto-start
 #   - Support both manual and supervisord execution
@@ -51,10 +51,10 @@
 # For more details, see: .devcontainer/additions/README-additions.md
 #
 #------------------------------------------------------------------------------
-# COMMANDS ARRAY PATTERN - Single source of truth for all operations
+# SCRIPT_COMMANDS ARRAY PATTERN - Single source of truth for all operations
 #------------------------------------------------------------------------------
 #
-# The COMMANDS array defines all available service operations. Each entry has 6 fields:
+# The SCRIPT_COMMANDS array defines all available service operations. Each entry has 6 fields:
 #
 # Format: "category|flag|description|function|requires_arg|param_prompt"
 #
@@ -76,7 +76,7 @@
 #   "Control|--stop|Stop service gracefully|service_stop|false|"
 #   "Status|--logs|Show recent logs|service_logs|true|Number of lines (default 50)"
 #
-# Benefits of COMMANDS array:
+# Benefits of SCRIPT_COMMANDS array:
 #   - Add new operation = just 1 line + implement function
 #   - Help text auto-generated
 #   - Menu integration automatic
@@ -92,11 +92,11 @@ SCRIPT_CATEGORY="INFRA_CONFIG"
 SCRIPT_PREREQUISITES=""  # Example: "config-example.sh" or "" if none
 
 #------------------------------------------------------------------------------
-# COMMAND DEFINITIONS - Single source of truth
+# SCRIPT_COMMANDS DEFINITIONS - Single source of truth
 #------------------------------------------------------------------------------
 
 # Format: category|flag|description|function|requires_arg|param_prompt
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Control|--start|Start service in foreground (for supervisord)|service_start|false|"
     "Control|--stop|Stop service gracefully|service_stop|false|"
     "Control|--restart|Restart service|service_restart|false|"
@@ -604,8 +604,8 @@ show_help() {
         source "${SCRIPT_DIR}/lib/cmd-framework.sh"
     fi
 
-    # Generate help from COMMANDS array (pass version as 3rd argument)
-    cmd_framework_generate_help COMMANDS "service-example.sh" "$SCRIPT_VER"
+    # Generate help from SCRIPT_COMMANDS array (pass version as 3rd argument)
+    cmd_framework_generate_help SCRIPT_COMMANDS "service-example.sh" "$SCRIPT_VER"
 
     # Add examples section
     echo ""
@@ -631,7 +631,7 @@ parse_args() {
     fi
 
     # Use framework to parse arguments
-    cmd_framework_parse_args COMMANDS "service-example.sh" "$@"
+    cmd_framework_parse_args SCRIPT_COMMANDS "service-example.sh" "$@"
 }
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/additions/cmd-ai.sh
+++ b/.devcontainer/additions/cmd-ai.sh
@@ -29,7 +29,7 @@ SCRIPT_PREREQUISITES="config-ai-claudecode.sh"
 #------------------------------------------------------------------------------
 
 # Format: category|flag|description|function|requires_arg|param_prompt
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Information|--models|List all models you have access to|cmd_models|false|"
     "Information|--info|Show user info (teams, budgets)|cmd_info|false|"
     "Information|--budget|Show budget status with usage percentage|cmd_budget|false|"
@@ -833,8 +833,8 @@ show_help() {
         source "${SCRIPT_DIR}/lib/cmd-framework.sh"
     fi
 
-    # Generate help from COMMANDS array (pass version as 3rd argument)
-    cmd_framework_generate_help COMMANDS "cmd-ai.sh" "$SCRIPT_VER"
+    # Generate help from SCRIPT_COMMANDS array (pass version as 3rd argument)
+    cmd_framework_generate_help SCRIPT_COMMANDS "cmd-ai.sh" "$SCRIPT_VER"
 
     # Add examples section
     echo ""
@@ -854,7 +854,7 @@ parse_args() {
     fi
 
     # Use framework to parse arguments
-    cmd_framework_parse_args COMMANDS "cmd-ai.sh" "$@"
+    cmd_framework_parse_args SCRIPT_COMMANDS "cmd-ai.sh" "$@"
 }
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/additions/install-dev-ai-claudecode.sh
+++ b/.devcontainer/additions/install-dev-ai-claudecode.sh
@@ -16,11 +16,12 @@ SCRIPT_DESCRIPTION="Installs Claude Code, Anthropic's terminal-based AI coding a
 SCRIPT_CATEGORY="AI_TOOLS"
 SCRIPT_CHECK_COMMAND="[ -f /home/vscode/.local/bin/claude ] || [ -f /usr/local/bin/claude ] || command -v claude >/dev/null 2>&1"
 
-# Optional: Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install Claude Code
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall Claude Code
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Claude Code||false|"
+    "Action|--uninstall|Uninstall Claude Code||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 #------------------------------------------------------------------------------
 

--- a/.devcontainer/additions/install-dev-cpp.sh
+++ b/.devcontainer/additions/install-dev-cpp.sh
@@ -15,10 +15,12 @@ SCRIPT_DESCRIPTION="Installs GCC, Clang, build tools, debuggers, and VS Code ext
 SCRIPT_CATEGORY="LANGUAGE_DEV"
 SCRIPT_CHECK_COMMAND="command -v gcc >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install C/C++ development tools||false|"
+    "Action|--uninstall|Uninstall C/C++ development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages
 PACKAGES_SYSTEM=(

--- a/.devcontainer/additions/install-dev-csharp.sh
+++ b/.devcontainer/additions/install-dev-csharp.sh
@@ -15,11 +15,12 @@ SCRIPT_DESCRIPTION="Installs .NET SDK, ASP.NET Core Runtime, and VS Code extensi
 SCRIPT_CATEGORY="LANGUAGE_DEV"
 SCRIPT_CHECK_COMMAND="[ -f $HOME/.dotnet/dotnet ] || [ -f /usr/bin/dotnet ] || command -v dotnet >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install .NET development environment
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall .NET packages
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install C# / .NET development tools||false|"
+    "Action|--uninstall|Uninstall C# / .NET development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # --- Default Configuration ---
 DEFAULT_VERSION="8.0"

--- a/.devcontainer/additions/install-dev-fortran.sh
+++ b/.devcontainer/additions/install-dev-fortran.sh
@@ -15,10 +15,14 @@ SCRIPT_DESCRIPTION="Installs GNU Fortran compiler (gfortran), build tools, and V
 SCRIPT_CATEGORY="LANGUAGE_DEV"
 SCRIPT_CHECK_COMMAND="command -v gfortran >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall"
+# Commands for dev-setup.sh menu integration
+# Format: category|flag|description|function|requires_arg|param_prompt
+# Note: Empty flag means "run with no arguments" (default install action)
+SCRIPT_COMMANDS=(
+    "Action||Install Fortran development tools||false|"
+    "Action|--uninstall|Uninstall Fortran development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages
 PACKAGES_SYSTEM=(

--- a/.devcontainer/additions/install-dev-golang.sh
+++ b/.devcontainer/additions/install-dev-golang.sh
@@ -15,11 +15,13 @@ SCRIPT_DESCRIPTION="Installs Go runtime, common tools, and VS Code extensions fo
 SCRIPT_CATEGORY="LANGUAGE_DEV"
 SCRIPT_CHECK_COMMAND="[ -f /usr/local/go/bin/go ] || [ -f /usr/bin/go ] || command -v go >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")                    # Install (default version)
-  $(basename "$0") --version X.Y.Z    # Install specific Go version (e.g., 1.21.0)
-  $(basename "$0") --help             # Show this help
-  $(basename "$0") --uninstall        # Uninstall"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Go with default version||false|"
+    "Action|--version|Install specific Go version||true|Enter Go version (e.g., 1.21.0)"
+    "Action|--uninstall|Uninstall Go development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages (all packages already in base devcontainer - see Dockerfile.base)
 PACKAGES_SYSTEM=()

--- a/.devcontainer/additions/install-dev-java.sh
+++ b/.devcontainer/additions/install-dev-java.sh
@@ -15,11 +15,13 @@ SCRIPT_DESCRIPTION="Installs Java JDK, Maven, Gradle, and VS Code extensions for
 SCRIPT_CATEGORY="LANGUAGE_DEV"
 SCRIPT_CHECK_COMMAND="[ -f /usr/bin/java ] || [ -f /usr/lib/jvm/*/bin/java ] || command -v java >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")                # Install (default version)
-  $(basename "$0") --version X    # Install specific Java version (e.g., 11, 17, 21)
-  $(basename "$0") --help         # Show this help
-  $(basename "$0") --uninstall    # Uninstall"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Java with default version||false|"
+    "Action|--version|Install specific Java version||true|Enter Java version (e.g., 11, 17, 21)"
+    "Action|--uninstall|Uninstall Java development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages (all packages already in base devcontainer - see Dockerfile.base)
 PACKAGES_SYSTEM=()

--- a/.devcontainer/additions/install-dev-php-laravel.sh
+++ b/.devcontainer/additions/install-dev-php-laravel.sh
@@ -15,11 +15,12 @@ SCRIPT_DESCRIPTION="Installs PHP 8.4, Composer, Laravel installer, and sets up L
 SCRIPT_CATEGORY="LANGUAGE_DEV"
 SCRIPT_CHECK_COMMAND="([ -f /usr/bin/php ] || command -v php >/dev/null 2>&1) && ([ -f /usr/local/bin/composer ] || command -v composer >/dev/null 2>&1) && ([ -f $HOME/.composer/vendor/bin/laravel ] || command -v laravel >/dev/null 2>&1)"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install PHP Laravel development environment
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall PHP Laravel tools
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install PHP Laravel development tools||false|"
+    "Action|--uninstall|Uninstall PHP Laravel development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # --- Default Configuration ---
 DEFAULT_VERSION="8.4"

--- a/.devcontainer/additions/install-dev-python.sh
+++ b/.devcontainer/additions/install-dev-python.sh
@@ -16,11 +16,12 @@ SCRIPT_DESCRIPTION="Adds ipython, pytest-cov, and VS Code extensions for Python 
 SCRIPT_CATEGORY="LANGUAGE_DEV"
 SCRIPT_CHECK_COMMAND="command -v ipython >/dev/null 2>&1"
 
-# Optional: Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install Python development environment
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall Python packages (Python runtime remains)
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Python development tools||false|"
+    "Action|--uninstall|Uninstall Python development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # Python packages (pytest, black, mypy already in base image)
 PACKAGES_PYTHON=(

--- a/.devcontainer/additions/install-dev-rust.sh
+++ b/.devcontainer/additions/install-dev-rust.sh
@@ -15,10 +15,12 @@ SCRIPT_DESCRIPTION="Installs Rust (latest stable via rustup), cargo, and sets up
 SCRIPT_CATEGORY="LANGUAGE_DEV"
 SCRIPT_CHECK_COMMAND="[ -f $HOME/.cargo/bin/rustc ] || command -v rustc >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Rust development tools||false|"
+    "Action|--uninstall|Uninstall Rust development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages
 PACKAGES_SYSTEM=(

--- a/.devcontainer/additions/install-dev-typescript.sh
+++ b/.devcontainer/additions/install-dev-typescript.sh
@@ -15,11 +15,12 @@ SCRIPT_DESCRIPTION="Adds TypeScript and development tools (Node.js already in de
 SCRIPT_CATEGORY="LANGUAGE_DEV"
 SCRIPT_CHECK_COMMAND="command -v tsc >/dev/null 2>&1 || npm list -g typescript 2>/dev/null | grep -q typescript"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install TypeScript development environment
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall TypeScript packages
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install TypeScript development tools||false|"
+    "Action|--uninstall|Uninstall TypeScript development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # Node.js packages
 PACKAGES_NODE=(

--- a/.devcontainer/additions/install-srv-nginx.sh
+++ b/.devcontainer/additions/install-srv-nginx.sh
@@ -16,11 +16,12 @@ SCRIPT_DESCRIPTION="Install nginx as reverse proxy for Claude Code ↔ LiteLLM w
 SCRIPT_CATEGORY="BACKGROUND_SERVICES"
 SCRIPT_CHECK_COMMAND="command -v nginx >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install nginx
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall nginx
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install nginx reverse proxy||false|"
+    "Action|--uninstall|Uninstall nginx||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages
 PACKAGES_SYSTEM=(

--- a/.devcontainer/additions/install-srv-otel-monitoring.sh
+++ b/.devcontainer/additions/install-srv-otel-monitoring.sh
@@ -21,11 +21,12 @@ SCRIPT_DESCRIPTION="Install OpenTelemetry Collector for devcontainer monitoring 
 SCRIPT_CATEGORY="BACKGROUND_SERVICES"
 SCRIPT_CHECK_COMMAND="([ -f /usr/bin/otelcol-contrib ] || command -v otelcol-contrib >/dev/null 2>&1) && ([ -f /usr/local/bin/script_exporter ] || command -v script_exporter >/dev/null 2>&1)"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install OpenTelemetry Collector
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall OpenTelemetry Collector
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install OpenTelemetry Collector||false|"
+    "Action|--uninstall|Uninstall OpenTelemetry Collector||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # OTel Collector configuration
 OTEL_VERSION="0.140.1"  # Latest stable version as of 2025-11

--- a/.devcontainer/additions/install-tool-api-dev.sh
+++ b/.devcontainer/additions/install-tool-api-dev.sh
@@ -16,11 +16,12 @@ SCRIPT_DESCRIPTION="Installs Thunder Client REST API client and OpenAPI Editor f
 SCRIPT_CATEGORY="CLOUD_TOOLS"
 SCRIPT_CHECK_COMMAND="code --list-extensions 2>/dev/null | grep -q 'rangav.vscode-thunder-client'"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install API development tools
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall API tools
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install API development tools||false|"
+    "Action|--uninstall|Uninstall API development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # --- Default Configuration ---
 # System packages (none needed - extensions only)

--- a/.devcontainer/additions/install-tool-azure-dev.sh
+++ b/.devcontainer/additions/install-tool-azure-dev.sh
@@ -17,11 +17,12 @@ SCRIPT_DESCRIPTION="Installs Azure CLI, Functions Core Tools, Azurite, and VS Co
 SCRIPT_CATEGORY="CLOUD_TOOLS"
 SCRIPT_CHECK_COMMAND="[ -f /usr/bin/az ] || [ -f /usr/local/bin/az ] || command -v az >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install Azure development tools
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall Azure tools
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Azure development tools||false|"
+    "Action|--uninstall|Uninstall Azure development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages
 PACKAGES_SYSTEM=(

--- a/.devcontainer/additions/install-tool-azure-ops.sh
+++ b/.devcontainer/additions/install-tool-azure-ops.sh
@@ -17,11 +17,12 @@ SCRIPT_DESCRIPTION="Installs Azure CLI, PowerShell with Az/Graph modules, and VS
 SCRIPT_CATEGORY="CLOUD_TOOLS"
 SCRIPT_CHECK_COMMAND="(command -v az >/dev/null 2>&1 && command -v pwsh >/dev/null 2>&1) || [ -f /usr/bin/pwsh ]"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install Azure ops tools
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall Azure ops tools
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Azure operations tools||false|"
+    "Action|--uninstall|Uninstall Azure operations tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # --- Default Configuration ---
 DEFAULT_VERSION="7.5.4"  # PowerShell 7.5.4 (latest stable as of October 2025)

--- a/.devcontainer/additions/install-tool-dataanalytics.sh
+++ b/.devcontainer/additions/install-tool-dataanalytics.sh
@@ -16,11 +16,12 @@ SCRIPT_DESCRIPTION="Installs Python data analysis libraries, Jupyter notebooks, 
 SCRIPT_CATEGORY="DATA_ANALYTICS"
 SCRIPT_CHECK_COMMAND="[ -f /usr/local/bin/jupyter ] || [ -f $HOME/.local/bin/jupyter ] || command -v jupyter >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install data analytics tools
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall analytics tools
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install data analytics tools||false|"
+    "Action|--uninstall|Uninstall data analytics tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages (all packages already in base devcontainer - see Dockerfile.base)
 PACKAGES_SYSTEM=()

--- a/.devcontainer/additions/install-tool-databricks.sh
+++ b/.devcontainer/additions/install-tool-databricks.sh
@@ -16,11 +16,12 @@ SCRIPT_DESCRIPTION="Installs Databricks CLI, Python SDK, Connect, and related to
 SCRIPT_CATEGORY="DATA_ANALYTICS"
 SCRIPT_CHECK_COMMAND="command -v databricks >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install Databricks tools
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall Databricks tools
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Databricks development tools||false|"
+    "Action|--uninstall|Uninstall Databricks development tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages
 PACKAGES_SYSTEM=()

--- a/.devcontainer/additions/install-tool-dev-utils.sh
+++ b/.devcontainer/additions/install-tool-dev-utils.sh
@@ -22,11 +22,12 @@ SCRIPT_CATEGORY="INFRA_CONFIG"
 # they don't need to update this check. The extension installer is idempotent anyway.
 SCRIPT_CHECK_COMMAND="code --list-extensions 2>/dev/null | grep -q 'mtxr.sqltools'"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install development utilities
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall utilities
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install development utilities||false|"
+    "Action|--uninstall|Uninstall development utilities||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages
 PACKAGES_SYSTEM=(

--- a/.devcontainer/additions/install-tool-iac.sh
+++ b/.devcontainer/additions/install-tool-iac.sh
@@ -16,11 +16,12 @@ SCRIPT_DESCRIPTION="Installs Infrastructure as Code and configuration management
 SCRIPT_CATEGORY="INFRA_CONFIG"
 SCRIPT_CHECK_COMMAND="command -v ansible >/dev/null 2>&1 || command -v terraform >/dev/null 2>&1 || command -v bicep >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install IaC tools
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall IaC tools
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Infrastructure as Code tools||false|"
+    "Action|--uninstall|Uninstall Infrastructure as Code tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages
 PACKAGES_SYSTEM=(

--- a/.devcontainer/additions/install-tool-kubernetes.sh
+++ b/.devcontainer/additions/install-tool-kubernetes.sh
@@ -16,27 +16,12 @@ SCRIPT_DESCRIPTION="Installs kubectl, k9s, helm and sets up .devcontainer.secret
 SCRIPT_CATEGORY="INFRA_CONFIG"
 SCRIPT_CHECK_COMMAND="command -v kubectl >/dev/null 2>&1 || command -v k9s >/dev/null 2>&1 || command -v helm >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install Kubernetes development tools
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall Kubernetes tools
-  $(basename "$0") --debug      # Install with debug output
-
-Authentication Setup:
-  After installation, kubectl requires authentication to connect to your cluster.
-  The installer creates helper scripts to copy your kubeconfig from the host.
-
-  On your HOST machine (Mac/Windows), run ONE of these scripts:
-    Mac:     bash .devcontainer.secrets/.kube/copy-kubeconfig-mac.sh
-    Windows: powershell .devcontainer.secrets/.kube/copy-kubeconfig-win.ps1
-
-  These scripts copy ~/.kube/config from your host and rewrite server URLs
-  to use host.docker.internal for container networking.
-
-  Inside the devcontainer, ~/.kube is symlinked to the secrets folder,
-  so kubectl automatically uses the copied configuration.
-
-  Test your connection: kubectl get nodes"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Kubernetes development tools||false|"
+    "Action|--uninstall|Uninstall Kubernetes tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # System packages
 PACKAGES_SYSTEM=()

--- a/.devcontainer/additions/install-tool-okta.sh
+++ b/.devcontainer/additions/install-tool-okta.sh
@@ -17,11 +17,12 @@ SCRIPT_DESCRIPTION="Installs Okta CLI and VS Code extensions for Okta identity a
 SCRIPT_CATEGORY="CLOUD_TOOLS"
 SCRIPT_CHECK_COMMAND="command -v okta-cli >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install Okta management tools
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall Okta tools
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Okta identity management tools||false|"
+    "Action|--uninstall|Uninstall Okta tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # --- Default Configuration ---
 # System packages (Python already in base devcontainer - see Dockerfile.base)

--- a/.devcontainer/additions/install-tool-powerplatform.sh
+++ b/.devcontainer/additions/install-tool-powerplatform.sh
@@ -17,11 +17,12 @@ SCRIPT_DESCRIPTION="Installs Power Platform CLI (pac - dotnet global tool), Powe
 SCRIPT_CATEGORY="CLOUD_TOOLS"
 SCRIPT_CHECK_COMMAND="[ -f $HOME/.dotnet/tools/pac ] || command -v pac >/dev/null 2>&1"
 
-# Custom usage text for --help
-SCRIPT_USAGE="  $(basename "$0")              # Install Power Platform development tools
-  $(basename "$0") --help       # Show this help
-  $(basename "$0") --uninstall  # Uninstall Power Platform tools
-  $(basename "$0") --debug      # Install with debug output"
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Install Power Platform tools||false|"
+    "Action|--uninstall|Uninstall Power Platform tools||false|"
+    "Info|--help|Show help and usage information||false|"
+)
 
 # --- Default Configuration ---
 # System packages (not needed - .NET SDK handled by prerequisite)

--- a/.devcontainer/additions/lib/cmd-framework.sh
+++ b/.devcontainer/additions/lib/cmd-framework.sh
@@ -4,7 +4,7 @@
 #
 # Purpose:
 #   Provides reusable functions for cmd-*.sh scripts to:
-#   - Parse COMMANDS array entries
+#   - Parse SCRIPT_COMMANDS array entries
 #   - Generate help text dynamically
 #   - Validate command definitions
 #   - Export command metadata as JSON
@@ -12,19 +12,19 @@
 # Usage:
 #   source "${SCRIPT_DIR}/lib/cmd-framework.sh"
 #
-#   # Define COMMANDS array in your script
-#   COMMANDS=(
+#   # Define SCRIPT_COMMANDS array in your script
+#   SCRIPT_COMMANDS=(
 #       "Category|--flag|Description|function_name|requires_arg|param_prompt"
 #       ...
 #   )
 #
 #   # Generate help text
-#   cmd_framework_generate_help COMMANDS "script-name.sh"
+#   cmd_framework_generate_help SCRIPT_COMMANDS "script-name.sh"
 #
 #   # Validate commands
-#   cmd_framework_validate_commands COMMANDS
+#   cmd_framework_validate_commands SCRIPT_COMMANDS
 #
-# COMMANDS Array Format (6 fields):
+# SCRIPT_COMMANDS Array Format (6 fields):
 #   Field 1: category      - Menu grouping (e.g., Information, Testing)
 #   Field 2: flag          - Command line flag (e.g., --models, --test)
 #   Field 3: description   - User-friendly description
@@ -42,12 +42,12 @@
 set -euo pipefail
 
 #------------------------------------------------------------------------------
-# Parse a single COMMANDS array entry
+# Parse a single SCRIPT_COMMANDS array entry
 #
 # Usage: cmd_framework_parse_command <command_definition>
 #
 # Arguments:
-#   command_definition - Single command entry from COMMANDS array
+#   command_definition - Single command entry from SCRIPT_COMMANDS array
 #
 # Returns: The parsed fields via stdout (pipe-separated)
 #   category|flag|description|function|requires_arg|param_prompt
@@ -68,19 +68,19 @@ cmd_framework_parse_command() {
 }
 
 #------------------------------------------------------------------------------
-# Generate help text from COMMANDS array
+# Generate help text from SCRIPT_COMMANDS array
 #
 # Usage: cmd_framework_generate_help <commands_array_name> <script_name>
 #
 # Arguments:
-#   commands_array_name - Name of the COMMANDS array variable (passed by name)
+#   commands_array_name - Name of the SCRIPT_COMMANDS array variable (passed by name)
 #   script_name        - Name of the script for usage line
 #
 # Returns: Formatted help text via stdout
 #
 # Example:
-#   COMMANDS=("Cat1|--cmd1|Desc1|func1|false|" "Cat2|--cmd2|Desc2|func2|true|Enter value")
-#   cmd_framework_generate_help COMMANDS "cmd-ai.sh"
+#   SCRIPT_COMMANDS=("Cat1|--cmd1|Desc1|func1|false|" "Cat2|--cmd2|Desc2|func2|true|Enter value")
+#   cmd_framework_generate_help SCRIPT_COMMANDS "cmd-ai.sh"
 #
 # Output:
 #   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -137,12 +137,12 @@ cmd_framework_generate_help() {
 }
 
 #------------------------------------------------------------------------------
-# Validate COMMANDS array format
+# Validate SCRIPT_COMMANDS array format
 #
 # Usage: cmd_framework_validate_commands <commands_array_name>
 #
 # Arguments:
-#   commands_array_name - Name of the COMMANDS array variable (passed by name)
+#   commands_array_name - Name of the SCRIPT_COMMANDS array variable (passed by name)
 #
 # Returns:
 #   Exit code: 0 if all valid, number of errors otherwise
@@ -154,8 +154,8 @@ cmd_framework_generate_help() {
 #   - requires_arg is either "true" or "false"
 #
 # Example:
-#   COMMANDS=("Cat|--cmd|Desc|func|false|")
-#   if cmd_framework_validate_commands COMMANDS; then
+#   SCRIPT_COMMANDS=("Cat|--cmd|Desc|func|false|")
+#   if cmd_framework_validate_commands SCRIPT_COMMANDS; then
 #       echo "All commands valid"
 #   fi
 #
@@ -172,7 +172,7 @@ cmd_framework_validate_commands() {
         local field_count=$(echo "$cmd_def" | awk -F'|' '{print NF}')
 
         if [ "$field_count" -ne 6 ]; then
-            echo "ERROR: Invalid COMMANDS entry (expected 6 fields, got $field_count):" >&2
+            echo "ERROR: Invalid SCRIPT_COMMANDS entry (expected 6 fields, got $field_count):" >&2
             echo "  $cmd_def" >&2
             ((errors++))
             continue
@@ -206,18 +206,18 @@ cmd_framework_validate_commands() {
 }
 
 #------------------------------------------------------------------------------
-# Export COMMANDS array as JSON
+# Export SCRIPT_COMMANDS array as JSON
 #
 # Usage: cmd_framework_export_json <commands_array_name>
 #
 # Arguments:
-#   commands_array_name - Name of the COMMANDS array variable (passed by name)
+#   commands_array_name - Name of the SCRIPT_COMMANDS array variable (passed by name)
 #
 # Returns: JSON representation via stdout
 #
 # Example:
-#   COMMANDS=("Cat|--cmd|Desc|func|false|")
-#   cmd_framework_export_json COMMANDS > commands.json
+#   SCRIPT_COMMANDS=("Cat|--cmd|Desc|func|false|")
+#   cmd_framework_export_json SCRIPT_COMMANDS > commands.json
 #
 # Output:
 #   {
@@ -286,14 +286,14 @@ EOF
 # Usage: cmd_framework_get_category <commands_array_name> <category_name>
 #
 # Arguments:
-#   commands_array_name - Name of the COMMANDS array variable (passed by name)
+#   commands_array_name - Name of the SCRIPT_COMMANDS array variable (passed by name)
 #   category_name       - Category to filter by
 #
 # Returns: Matching command entries via stdout (one per line)
 #
 # Example:
-#   COMMANDS=("Cat1|--cmd1|Desc1|func1|false|" "Cat2|--cmd2|Desc2|func2|true|Enter")
-#   cmd_framework_get_category COMMANDS "Cat1"
+#   SCRIPT_COMMANDS=("Cat1|--cmd1|Desc1|func1|false|" "Cat2|--cmd2|Desc2|func2|true|Enter")
+#   cmd_framework_get_category SCRIPT_COMMANDS "Cat1"
 #   # Output: Cat1|--cmd1|Desc1|func1|false|
 #
 #------------------------------------------------------------------------------
@@ -314,18 +314,18 @@ cmd_framework_get_category() {
 }
 
 #------------------------------------------------------------------------------
-# Get all unique categories from COMMANDS array
+# Get all unique categories from SCRIPT_COMMANDS array
 #
 # Usage: cmd_framework_get_categories <commands_array_name>
 #
 # Arguments:
-#   commands_array_name - Name of the COMMANDS array variable (passed by name)
+#   commands_array_name - Name of the SCRIPT_COMMANDS array variable (passed by name)
 #
 # Returns: List of unique categories via stdout (one per line, in order)
 #
 # Example:
-#   COMMANDS=("Cat1|--cmd1|Desc1|func1|false|" "Cat2|--cmd2|Desc2|func2|true|Enter")
-#   cmd_framework_get_categories COMMANDS
+#   SCRIPT_COMMANDS=("Cat1|--cmd1|Desc1|func1|false|" "Cat2|--cmd2|Desc2|func2|true|Enter")
+#   cmd_framework_get_categories SCRIPT_COMMANDS
 #   # Output:
 #   # Cat1
 #   # Cat2
@@ -364,14 +364,14 @@ cmd_framework_get_categories() {
 # Usage: cmd_framework_find_command <commands_array_name> <flag>
 #
 # Arguments:
-#   commands_array_name - Name of the COMMANDS array variable (passed by name)
+#   commands_array_name - Name of the SCRIPT_COMMANDS array variable (passed by name)
 #   flag                - Flag to search for (e.g., --test)
 #
 # Returns: Matching command entry via stdout (empty if not found)
 #
 # Example:
-#   COMMANDS=("Cat|--test|Test model|cmd_test|true|Enter model")
-#   cmd_def=$(cmd_framework_find_command COMMANDS "--test")
+#   SCRIPT_COMMANDS=("Cat|--test|Test model|cmd_test|true|Enter model")
+#   cmd_def=$(cmd_framework_find_command SCRIPT_COMMANDS "--test")
 #   # Output: Cat|--test|Test model|cmd_test|true|Enter model
 #
 #------------------------------------------------------------------------------
@@ -400,7 +400,7 @@ cmd_framework_find_command() {
 # Usage: cmd_framework_parse_args <commands_array_name> <script_name> "$@"
 #
 # Arguments:
-#   commands_array_name - Name of the COMMANDS array variable (passed by name)
+#   commands_array_name - Name of the SCRIPT_COMMANDS array variable (passed by name)
 #   script_name        - Name of the script (for error messages)
 #   $@                 - All command-line arguments passed to the script
 #
@@ -408,13 +408,13 @@ cmd_framework_find_command() {
 # Exit code: 0 on success, 1 on error
 #
 # Example in cmd-ai.sh:
-#   COMMANDS=(
+#   SCRIPT_COMMANDS=(
 #       "Testing|--test|Test model|cmd_test|true|Enter model name"
 #       "Info|--models|List models|cmd_models|false|"
 #   )
 #
 #   parse_args() {
-#       cmd_framework_parse_args COMMANDS "cmd-ai.sh" "$@"
+#       cmd_framework_parse_args SCRIPT_COMMANDS "cmd-ai.sh" "$@"
 #   }
 #
 #------------------------------------------------------------------------------
@@ -438,7 +438,7 @@ cmd_framework_parse_args() {
         return 0
     fi
 
-    # Look up command in COMMANDS array
+    # Look up command in SCRIPT_COMMANDS array
     local cmd_def
     if ! cmd_def=$(cmd_framework_find_command "$array_name" "$flag"); then
         echo "ERROR: Unknown command: $flag" >&2
@@ -473,7 +473,7 @@ cmd_framework_self_test() {
     echo ""
 
     # Test data
-    local TEST_COMMANDS=(
+    local TEST_SCRIPT_COMMANDS=(
         "Information|--models|List all models|cmd_models|false|"
         "Information|--info|Show user info|cmd_info|false|"
         "Testing|--test|Test specific model|cmd_test|true|Enter model name"
@@ -484,7 +484,7 @@ cmd_framework_self_test() {
 
     # Test 1: Parse command
     echo "Test 1: Parse command"
-    local result=$(cmd_framework_parse_command "${TEST_COMMANDS[0]}")
+    local result=$(cmd_framework_parse_command "${TEST_SCRIPT_COMMANDS[0]}")
     if [[ "$result" == "Information|--models|List all models|cmd_models|false|" ]]; then
         echo "  ✅ PASS"
     else
@@ -495,7 +495,7 @@ cmd_framework_self_test() {
 
     # Test 2: Generate help
     echo "Test 2: Generate help"
-    local help_output=$(cmd_framework_generate_help TEST_COMMANDS "test.sh")
+    local help_output=$(cmd_framework_generate_help TEST_SCRIPT_COMMANDS "test.sh")
     if [[ "$help_output" == *"Information Commands:"* ]] && [[ "$help_output" == *"Testing Commands:"* ]]; then
         echo "  ✅ PASS"
     else
@@ -506,7 +506,7 @@ cmd_framework_self_test() {
 
     # Test 3: Validate commands
     echo "Test 3: Validate commands"
-    if cmd_framework_validate_commands TEST_COMMANDS 2>/dev/null; then
+    if cmd_framework_validate_commands TEST_SCRIPT_COMMANDS 2>/dev/null; then
         echo "  ✅ PASS"
     else
         echo "  ❌ FAIL: Validation failed"
@@ -516,8 +516,8 @@ cmd_framework_self_test() {
 
     # Test 4: Invalid command format
     echo "Test 4: Invalid command format (should fail)"
-    local INVALID_COMMANDS=("Cat|--flag|Desc|func")  # Only 4 fields
-    if cmd_framework_validate_commands INVALID_COMMANDS 2>/dev/null; then
+    local INVALID_SCRIPT_COMMANDS=("Cat|--flag|Desc|func")  # Only 4 fields
+    if cmd_framework_validate_commands INVALID_SCRIPT_COMMANDS 2>/dev/null; then
         echo "  ❌ FAIL: Should have detected invalid format"
         ((errors++))
     else
@@ -527,7 +527,7 @@ cmd_framework_self_test() {
 
     # Test 5: Get categories
     echo "Test 5: Get categories"
-    local categories=$(cmd_framework_get_categories TEST_COMMANDS)
+    local categories=$(cmd_framework_get_categories TEST_SCRIPT_COMMANDS)
     if [[ "$categories" == *"Information"* ]] && [[ "$categories" == *"Testing"* ]]; then
         echo "  ✅ PASS"
     else
@@ -538,7 +538,7 @@ cmd_framework_self_test() {
 
     # Test 6: Find command
     echo "Test 6: Find command by flag"
-    local found=$(cmd_framework_find_command TEST_COMMANDS "--test")
+    local found=$(cmd_framework_find_command TEST_SCRIPT_COMMANDS "--test")
     if [[ "$found" == *"cmd_test"* ]]; then
         echo "  ✅ PASS"
     else
@@ -549,7 +549,7 @@ cmd_framework_self_test() {
 
     # Test 7: Export JSON
     echo "Test 7: Export JSON"
-    local json_output=$(cmd_framework_export_json TEST_COMMANDS)
+    local json_output=$(cmd_framework_export_json TEST_SCRIPT_COMMANDS)
     if [[ "$json_output" == *'"commands":'* ]] && [[ "$json_output" == *'"flag": "--models"'* ]]; then
         echo "  ✅ PASS"
     else

--- a/.devcontainer/additions/lib/component-scanner.sh
+++ b/.devcontainer/additions/lib/component-scanner.sh
@@ -364,15 +364,15 @@ extract_service_script_metadata() {
     return 0
 }
 
-# Extract COMMANDS array from service-*.sh script
+# Extract SCRIPT_COMMANDS array from service-*.sh script
 #
 # Usage: extract_service_commands <script_path>
 #
 # Arguments:
 #   script_path - Absolute path to the service-*.sh script
 #
-# Returns: COMMANDS array entries, one per line
-# Exit code: 0 on success, 1 if script not found or COMMANDS array not found
+# Returns: SCRIPT_COMMANDS array entries, one per line
+# Exit code: 0 on success, 1 if script not found or SCRIPT_COMMANDS array not found
 #
 # Example:
 #   while IFS= read -r cmd_def; do
@@ -394,10 +394,10 @@ extract_service_commands() {
         return 1
     fi
 
-    # Extract COMMANDS array from file
-    # Find lines between COMMANDS=( and closing )
-    sed -n '/^COMMANDS=(/,/^)/p' "$script_path" 2>/dev/null | \
-        grep -v '^COMMANDS=(' | \
+    # Extract SCRIPT_COMMANDS array from file
+    # Find lines between SCRIPT_COMMANDS=( and closing )
+    sed -n '/^SCRIPT_COMMANDS=(/,/^)/p' "$script_path" 2>/dev/null | \
+        grep -v '^SCRIPT_COMMANDS=(' | \
         grep -v '^)' | \
         sed 's/^[[:space:]]*//' | \
         sed 's/"$//' | \
@@ -669,22 +669,22 @@ extract_cmd_metadata() {
     return 0
 }
 
-# Extract COMMANDS array from cmd-*.sh script
+# Extract SCRIPT_COMMANDS array from any script
 #
-# Usage: extract_cmd_commands <script_path>
+# Usage: extract_script_commands <script_path>
 #
 # Arguments:
-#   script_path - Absolute path to the cmd-*.sh script
+#   script_path - Absolute path to the script (install-*.sh, cmd-*.sh, service-*.sh)
 #
-# Returns: COMMANDS array entries, one per line
-# Exit code: 0 on success, 1 if script not found or COMMANDS array not found
+# Returns: SCRIPT_COMMANDS array entries, one per line
+# Exit code: 0 on success, 1 if script not found or SCRIPT_COMMANDS array not found
 #
 # Example:
 #   while IFS= read -r cmd_def; do
 #       echo "Command: $cmd_def"
-#   done < <(extract_cmd_commands "/path/to/cmd-ai.sh")
+#   done < <(extract_script_commands "/path/to/install-dev-fortran.sh")
 #
-extract_cmd_commands() {
+extract_script_commands() {
     local script_path="$1"
 
     # Validate input
@@ -699,14 +699,19 @@ extract_cmd_commands() {
         return 1
     fi
 
-    # Extract COMMANDS array from file
-    # Find lines between COMMANDS=( and closing )
-    sed -n '/^COMMANDS=(/,/^)/p' "$script_path" 2>/dev/null | \
-        grep -v '^COMMANDS=(' | \
+    # Extract SCRIPT_COMMANDS array from file
+    # Find lines between SCRIPT_COMMANDS=( and closing )
+    sed -n '/^SCRIPT_COMMANDS=(/,/^)/p' "$script_path" 2>/dev/null | \
+        grep -v '^SCRIPT_COMMANDS=(' | \
         grep -v '^)' | \
         sed 's/^[[:space:]]*//' | \
         sed 's/"$//' | \
         sed 's/^"//'
+}
+
+# Legacy alias for backward compatibility
+extract_cmd_commands() {
+    extract_script_commands "$@"
 }
 
 # Scan all cmd-*.sh scripts and output structured data

--- a/.devcontainer/additions/service-nginx.sh
+++ b/.devcontainer/additions/service-nginx.sh
@@ -28,10 +28,10 @@ SERVICE_DEPENDS=""
 SERVICE_AUTO_RESTART="true"
 
 #------------------------------------------------------------------------------
-# COMMANDS ARRAY - Single source of truth for all operations
+# SCRIPT_COMMANDS ARRAY - Single source of truth for all operations
 #------------------------------------------------------------------------------
 
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Control|--start|Start nginx in foreground (for supervisord)|service_start|false|"
     "Control|--stop|Stop nginx gracefully|service_stop|false|"
     "Control|--restart|Restart nginx service|service_restart|false|"
@@ -686,15 +686,15 @@ service_health() {
 #------------------------------------------------------------------------------
 
 show_help() {
-    # Use cmd-framework.sh to generate help text from COMMANDS array (pass version as 3rd argument)
+    # Use cmd-framework.sh to generate help text from SCRIPT_COMMANDS array (pass version as 3rd argument)
     source "${SCRIPT_DIR}/lib/cmd-framework.sh"
-    cmd_framework_generate_help COMMANDS "service-nginx.sh" "$SCRIPT_VER"
+    cmd_framework_generate_help SCRIPT_COMMANDS "service-nginx.sh" "$SCRIPT_VER"
 }
 
 parse_args() {
     # Use cmd-framework.sh to parse arguments and call appropriate function
     source "${SCRIPT_DIR}/lib/cmd-framework.sh"
-    cmd_framework_parse_args COMMANDS "service-nginx.sh" "$@"
+    cmd_framework_parse_args SCRIPT_COMMANDS "service-nginx.sh" "$@"
 }
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/additions/service-otel-monitoring.sh
+++ b/.devcontainer/additions/service-otel-monitoring.sh
@@ -32,10 +32,10 @@ SERVICE_DEPENDS="service-nginx"  # Sends data through nginx reverse proxy
 SERVICE_AUTO_RESTART="true"
 
 #------------------------------------------------------------------------------
-# COMMANDS ARRAY - Single source of truth for all operations
+# SCRIPT_COMMANDS ARRAY - Single source of truth for all operations
 #------------------------------------------------------------------------------
 
-COMMANDS=(
+SCRIPT_COMMANDS=(
     "Control|--start|Start all OTel services (for supervisord)|service_start|false|"
     "Control|--stop|Stop all OTel services|service_stop|false|"
     "Control|--restart|Restart all OTel services|service_restart|false|"
@@ -958,15 +958,15 @@ service_health() {
 #------------------------------------------------------------------------------
 
 show_help() {
-    # Use cmd-framework.sh to generate help text from COMMANDS array (pass version as 3rd argument)
+    # Use cmd-framework.sh to generate help text from SCRIPT_COMMANDS array (pass version as 3rd argument)
     source "${SCRIPT_DIR}/lib/cmd-framework.sh"
-    cmd_framework_generate_help COMMANDS "service-otel-monitoring.sh" "$SCRIPT_VER"
+    cmd_framework_generate_help SCRIPT_COMMANDS "service-otel-monitoring.sh" "$SCRIPT_VER"
 }
 
 parse_args() {
     # Use cmd-framework.sh to parse arguments and call appropriate function
     source "${SCRIPT_DIR}/lib/cmd-framework.sh"
-    cmd_framework_parse_args COMMANDS "service-otel-monitoring.sh" "$@"
+    cmd_framework_parse_args SCRIPT_COMMANDS "service-otel-monitoring.sh" "$@"
 }
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/additions/tests/static/test-metadata.sh
+++ b/.devcontainer/additions/tests/static/test-metadata.sh
@@ -35,6 +35,11 @@ test_install_scripts_metadata() {
         [[ -z "$script_cat" ]] && missing+="SCRIPT_CATEGORY "
         [[ -z "$check_cmd" ]] && missing+="SCRIPT_CHECK_COMMAND "
 
+        # Check SCRIPT_COMMANDS array exists (for menu integration)
+        if ! grep -q "^SCRIPT_COMMANDS=(" "$script" 2>/dev/null; then
+            missing+="SCRIPT_COMMANDS "
+        fi
+
         if [[ -n "$missing" ]]; then
             echo "  ✗ $name - missing: $missing"
             ((failed++))
@@ -97,9 +102,9 @@ test_service_scripts_metadata() {
         [[ -z "$script_desc" ]] && missing+="SCRIPT_DESCRIPTION "
         [[ -z "$script_cat" ]] && missing+="SCRIPT_CATEGORY "
 
-        # Check COMMANDS array exists
-        if ! grep -q "^COMMANDS=(" "$script" 2>/dev/null; then
-            missing+="COMMANDS "
+        # Check SCRIPT_COMMANDS array exists
+        if ! grep -q "^SCRIPT_COMMANDS=(" "$script" 2>/dev/null; then
+            missing+="SCRIPT_COMMANDS "
         fi
 
         if [[ -n "$missing" ]]; then
@@ -132,9 +137,9 @@ test_cmd_scripts_metadata() {
         [[ -z "$script_desc" ]] && missing+="SCRIPT_DESCRIPTION "
         [[ -z "$script_cat" ]] && missing+="SCRIPT_CATEGORY "
 
-        # Check COMMANDS array exists
-        if ! grep -q "^COMMANDS=(" "$script" 2>/dev/null; then
-            missing+="COMMANDS "
+        # Check SCRIPT_COMMANDS array exists
+        if ! grep -q "^SCRIPT_COMMANDS=(" "$script" 2>/dev/null; then
+            missing+="SCRIPT_COMMANDS "
         fi
 
         if [[ -n "$missing" ]]; then


### PR DESCRIPTION
## Summary
- Remove SCRIPT_USAGE from all install scripts and replace with SCRIPT_COMMANDS array
- SCRIPT_COMMANDS provides single source of truth for both help generation and menu integration
- Rename COMMANDS to SCRIPT_COMMANDS for consistent SCRIPT_* prefix convention

## Changes
- 22 install scripts: removed SCRIPT_USAGE, added SCRIPT_COMMANDS
- 2 service scripts: updated to use SCRIPT_COMMANDS
- 1 cmd script: updated to use SCRIPT_COMMANDS
- lib/install-common.sh: generate help from SCRIPT_COMMANDS
- lib/cmd-framework.sh: updated documentation
- lib/component-scanner.sh: updated to extract SCRIPT_COMMANDS
- Templates and documentation updated

## Test plan
- [ ] Run static tests: `bash .devcontainer/additions/tests/run-all-tests.sh`
- [ ] Verify `--help` works on install scripts
- [ ] Verify dev-setup.sh menu shows correct options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces COMMANDS/SCRIPT_USAGE with SCRIPT_COMMANDS across scripts, updates libraries and dev-setup to parse/use it, and refreshes docs/templates/tests.
> 
> - **Core libraries**:
>   - `lib/cmd-framework.sh`: Docs/comments switched to `SCRIPT_COMMANDS`.
>   - `lib/component-scanner.sh`: New `extract_script_commands` for generic `SCRIPT_COMMANDS`; legacy alias kept; service/cmd extractors updated.
>   - `lib/install-common.sh`: `show_script_help` now generates usage from `SCRIPT_COMMANDS`.
> - **Dev menu (`dev-setup.sh`)**:
>   - Reads `SCRIPT_COMMANDS` for services, cmds, and now install scripts; adds per-tool action submenu and executor (`execute_tool_action`).
> - **Tests**:
>   - `tests/static/test-metadata.sh`: Require `SCRIPT_COMMANDS` in install/service/cmd scripts.
> - **Templates & Docs**:
>   - All README templates and `_template-*.sh` files renamed `COMMANDS` → `SCRIPT_COMMANDS`; examples/help calls updated.
> - **Scripts updated**:
>   - Services: `service-nginx.sh`, `service-otel-monitoring.sh` now use `SCRIPT_COMMANDS` in help/parse.
>   - Cmd: `cmd-ai.sh` switched to `SCRIPT_COMMANDS` in array/help/parse.
>   - Install scripts (multiple): Added `SCRIPT_COMMANDS` arrays for menu actions (install/uninstall/help).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab3c90affbdec12c61f833a394afe591b2c78f09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->