### PR TITLE
refactor: standardize config and service script metadata

### DIFF
--- a/.devcontainer/additions/addition-templates/_template-cmd-script.sh
+++ b/.devcontainer/additions/addition-templates/_template-cmd-script.sh
@@ -72,10 +72,11 @@
 #
 #------------------------------------------------------------------------------
 
+SCRIPT_ID="cmd-example"  # Unique identifier (must match filename without .sh)
 SCRIPT_NAME="Example Management"
 SCRIPT_VER="0.0.1"  # Script version - displayed in --help
 SCRIPT_DESCRIPTION="Manage and analyze example resources"
-SCRIPT_CATEGORY="UNCATEGORIZED"
+SCRIPT_CATEGORY="INFRA_CONFIG"  # Options: LANGUAGE_DEV, AI_TOOLS, CLOUD_TOOLS, DATA_ANALYTICS, BACKGROUND_SERVICES, INFRA_CONFIG
 SCRIPT_PREREQUISITES=""  # Example: "config-example.sh" or "" if none
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/additions/addition-templates/_template-config-script.sh
+++ b/.devcontainer/additions/addition-templates/_template-config-script.sh
@@ -141,11 +141,20 @@
 # CONFIGURATION METADATA - For dev-setup.sh menu discovery
 #------------------------------------------------------------------------------
 
+SCRIPT_ID="config-[name]"  # Unique identifier (must match filename without .sh)
 SCRIPT_NAME="[Configuration Name]"
 SCRIPT_VER="0.0.1"  # Script version - displayed during configuration
 SCRIPT_DESCRIPTION="Configure [setting/credential/identity] for [purpose]"
 SCRIPT_CATEGORY="USER_CONFIG"  # Options: INFRA_CONFIG, USER_CONFIG, SECURITY, CREDENTIALS
 SCRIPT_CHECK_COMMAND="[ -f ~/.config-file ] && grep -q '^key=value' ~/.config-file"
+
+# Commands for dev-setup.sh menu integration
+SCRIPT_COMMANDS=(
+    "Action||Configure [setting] interactively||false|"
+    "Action|--show|Display current configuration||false|"
+    "Action|--verify|Restore from .devcontainer.secrets||false|"
+    "Info|--help|Show help information||false|"
+)
 
 #------------------------------------------------------------------------------
 

--- a/.devcontainer/additions/addition-templates/_template-config-script.sh
+++ b/.devcontainer/additions/addition-templates/_template-config-script.sh
@@ -145,8 +145,9 @@ SCRIPT_ID="config-[name]"  # Unique identifier (must match filename without .sh)
 SCRIPT_NAME="[Configuration Name]"
 SCRIPT_VER="0.0.1"  # Script version - displayed during configuration
 SCRIPT_DESCRIPTION="Configure [setting/credential/identity] for [purpose]"
-SCRIPT_CATEGORY="USER_CONFIG"  # Options: INFRA_CONFIG, USER_CONFIG, SECURITY, CREDENTIALS
+SCRIPT_CATEGORY="INFRA_CONFIG"  # Options: LANGUAGE_DEV, AI_TOOLS, CLOUD_TOOLS, DATA_ANALYTICS, BACKGROUND_SERVICES, INFRA_CONFIG
 SCRIPT_CHECK_COMMAND="[ -f ~/.config-file ] && grep -q '^key=value' ~/.config-file"
+SCRIPT_PREREQUISITES=""  # Example: "config-other.sh" or "" if none - comma-separated for multiple
 
 # Commands for dev-setup.sh menu integration
 SCRIPT_COMMANDS=(

--- a/.devcontainer/additions/addition-templates/_template-install-script.sh
+++ b/.devcontainer/additions/addition-templates/_template-install-script.sh
@@ -102,7 +102,7 @@ SCRIPT_ID="[category-name]"  # Unique identifier (e.g., dev-python, tool-azure, 
 SCRIPT_VER="0.0.1"           # Script version - displayed in --help and during install/uninstall
 SCRIPT_NAME="[Name]"
 SCRIPT_DESCRIPTION="[Brief description of what this script installs and its purpose]"
-SCRIPT_CATEGORY="DEV_TOOLS"  # Options: DEV_TOOLS, INFRA_CONFIG, AI_TOOLS, MONITORING, DATABASE, CLOUD
+SCRIPT_CATEGORY="LANGUAGE_DEV"  # Options: LANGUAGE_DEV, AI_TOOLS, CLOUD_TOOLS, DATA_ANALYTICS, BACKGROUND_SERVICES, INFRA_CONFIG
 SCRIPT_CHECK_COMMAND="command -v [tool-name] >/dev/null 2>&1"  # Command to check if already installed
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/additions/addition-templates/_template-service-script.sh
+++ b/.devcontainer/additions/addition-templates/_template-service-script.sh
@@ -89,9 +89,13 @@ SCRIPT_ID="service-example"  # Unique identifier (must match filename without .s
 SCRIPT_NAME="Example Service"
 SCRIPT_VER="0.0.1"  # Script version - displayed in --help
 SCRIPT_DESCRIPTION="Example background service for demonstration"
-SCRIPT_CATEGORY="INFRA_CONFIG"
+SCRIPT_CATEGORY="BACKGROUND_SERVICES"  # Use: BACKGROUND_SERVICES, INFRA_CONFIG
 SCRIPT_CHECK_COMMAND="pgrep -f 'example-service' >/dev/null 2>&1"  # Check if service is running
 SCRIPT_PREREQUISITES=""  # Example: "config-example.sh" or "" if none
+
+# Supervisor integration - controls startup order and dependencies
+SERVICE_PRIORITY="50"  # Lower numbers start first (10=first, 99=last). nginx=20, otel=30
+SERVICE_DEPENDS=""     # Comma-separated service IDs this depends on. Example: "service-nginx"
 
 #------------------------------------------------------------------------------
 # SCRIPT_COMMANDS DEFINITIONS - Single source of truth

--- a/.devcontainer/additions/addition-templates/_template-service-script.sh
+++ b/.devcontainer/additions/addition-templates/_template-service-script.sh
@@ -85,10 +85,12 @@
 #
 #------------------------------------------------------------------------------
 
+SCRIPT_ID="service-example"  # Unique identifier (must match filename without .sh)
 SCRIPT_NAME="Example Service"
 SCRIPT_VER="0.0.1"  # Script version - displayed in --help
 SCRIPT_DESCRIPTION="Example background service for demonstration"
 SCRIPT_CATEGORY="INFRA_CONFIG"
+SCRIPT_CHECK_COMMAND="pgrep -f 'example-service' >/dev/null 2>&1"  # Check if service is running
 SCRIPT_PREREQUISITES=""  # Example: "config-example.sh" or "" if none
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/additions/cmd-ai.sh
+++ b/.devcontainer/additions/cmd-ai.sh
@@ -18,6 +18,7 @@
 # SCRIPT METADATA - For dev-setup.sh discovery
 #------------------------------------------------------------------------------
 
+SCRIPT_ID="cmd-ai"  # Unique identifier (must match filename without .sh)
 SCRIPT_NAME="AI Management"
 SCRIPT_VER="0.0.1"
 SCRIPT_DESCRIPTION="Manage AI models, spending, and usage through LiteLLM"

--- a/.devcontainer/additions/install-dev-rust.sh
+++ b/.devcontainer/additions/install-dev-rust.sh
@@ -40,7 +40,7 @@ PACKAGES_CARGO=(
 EXTENSIONS=(
     "Rust Analyzer (rust-lang.rust-analyzer) - Rust language support with rust-analyzer"
     "CodeLLDB (vadimcn.vscode-lldb) - Native debugger for Rust"
-    "Crates (serayuzgur.crates) - Helps manage Rust dependencies"
+    "Dependi (serayuzgur.dependi) - Replacement for Crates; manages Rust dependencies"
 )
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/additions/lib/component-scanner.sh
+++ b/.devcontainer/additions/lib/component-scanner.sh
@@ -559,12 +559,12 @@ check_config_configured() {
 #   additions_dir - Directory containing config-*.sh scripts
 #
 # Output format (tab-separated, one line per config):
-#   script_basename<TAB>SCRIPT_NAME<TAB>SCRIPT_DESCRIPTION<TAB>SCRIPT_CATEGORY<TAB>SCRIPT_CHECK_COMMAND
+#   script_basename<TAB>SCRIPT_NAME<TAB>SCRIPT_DESCRIPTION<TAB>SCRIPT_CATEGORY<TAB>SCRIPT_CHECK_COMMAND<TAB>SCRIPT_PREREQUISITES
 #
 # Exit code: 0 on success, 1 if directory not found
 #
 # Example:
-#   while IFS=$'\t' read -r basename name desc cat check; do
+#   while IFS=$'\t' read -r basename name desc cat check prereqs; do
 #       echo "Config: $name (category: $cat)"
 #   done < <(scan_config_scripts "/workspace/.devcontainer/additions")
 #
@@ -597,6 +597,7 @@ scan_config_scripts() {
         local config_description=$(extract_config_metadata "$script" "SCRIPT_DESCRIPTION")
         local config_category=$(extract_config_metadata "$script" "SCRIPT_CATEGORY")
         local check_command=$(extract_config_metadata "$script" "SCRIPT_CHECK_COMMAND")
+        local prerequisites=$(extract_config_metadata "$script" "SCRIPT_PREREQUISITES")
 
         # Skip if no SCRIPT_NAME found (invalid config)
         if [[ -z "$config_name" ]]; then
@@ -614,12 +615,13 @@ scan_config_scripts() {
         fi
 
         # Output tab-separated values
-        printf "%s\t%s\t%s\t%s\t%s\n" \
+        printf "%s\t%s\t%s\t%s\t%s\t%s\n" \
             "$script_basename" \
             "$config_name" \
             "$config_description" \
             "$config_category" \
-            "$check_command"
+            "$check_command" \
+            "$prerequisites"
     done
 
     return 0

--- a/.devcontainer/additions/service-nginx.sh
+++ b/.devcontainer/additions/service-nginx.sh
@@ -19,6 +19,7 @@ SCRIPT_NAME="Nginx Reverse Proxy"
 SCRIPT_VER="0.0.1"
 SCRIPT_DESCRIPTION="Nginx reverse proxy for LiteLLM (adds Host header)"
 SCRIPT_CATEGORY="INFRA_CONFIG"
+SCRIPT_CHECK_COMMAND="pgrep -x nginx >/dev/null 2>&1"
 SCRIPT_PREREQUISITES=""  # Optional: "config-nginx.sh" if required
 SCRIPT_PREREQUISITE_TOOLS="install-srv-nginx.sh"  # Must be installed first
 

--- a/.devcontainer/additions/service-otel-monitoring.sh
+++ b/.devcontainer/additions/service-otel-monitoring.sh
@@ -23,6 +23,7 @@ SCRIPT_NAME="OTel Monitoring"
 SCRIPT_VER="0.0.1"
 SCRIPT_DESCRIPTION="OpenTelemetry monitoring stack (lifecycle, metrics, script exporter)"
 SCRIPT_CATEGORY="INFRA_CONFIG"
+SCRIPT_CHECK_COMMAND="pgrep -f 'otelcol.*--config' >/dev/null 2>&1"
 SCRIPT_PREREQUISITES="config-devcontainer-identity.sh"
 SCRIPT_PREREQUISITE_TOOLS="install-srv-otel-monitoring.sh"  # Must be installed first
 

--- a/.devcontainer/additions/tests/static/test-metadata.sh
+++ b/.devcontainer/additions/tests/static/test-metadata.sh
@@ -138,11 +138,13 @@ test_cmd_scripts_metadata() {
         local missing=""
 
         # Check required fields (all scripts use SCRIPT_* prefix)
+        local script_id=$(grep -m 1 "^SCRIPT_ID=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_name=$(grep -m 1 "^SCRIPT_NAME=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_ver=$(grep -m 1 "^SCRIPT_VER=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_desc=$(grep -m 1 "^SCRIPT_DESCRIPTION=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_cat=$(grep -m 1 "^SCRIPT_CATEGORY=" "$script" 2>/dev/null | cut -d'"' -f2)
 
+        [[ -z "$script_id" ]] && missing+="SCRIPT_ID "
         [[ -z "$script_name" ]] && missing+="SCRIPT_NAME "
         [[ -z "$script_ver" ]] && missing+="SCRIPT_VER "
         [[ -z "$script_desc" ]] && missing+="SCRIPT_DESCRIPTION "

--- a/.devcontainer/additions/tests/static/test-metadata.sh
+++ b/.devcontainer/additions/tests/static/test-metadata.sh
@@ -60,17 +60,24 @@ test_config_scripts_metadata() {
         local missing=""
 
         # Check required fields (all scripts use SCRIPT_* prefix)
+        local script_id=$(grep -m 1 "^SCRIPT_ID=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_name=$(grep -m 1 "^SCRIPT_NAME=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_ver=$(grep -m 1 "^SCRIPT_VER=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_desc=$(grep -m 1 "^SCRIPT_DESCRIPTION=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_cat=$(grep -m 1 "^SCRIPT_CATEGORY=" "$script" 2>/dev/null | cut -d'"' -f2)
         local check_cmd=$(grep -m 1 "^SCRIPT_CHECK_COMMAND=" "$script" 2>/dev/null | cut -d'"' -f2)
 
+        [[ -z "$script_id" ]] && missing+="SCRIPT_ID "
         [[ -z "$script_name" ]] && missing+="SCRIPT_NAME "
         [[ -z "$script_ver" ]] && missing+="SCRIPT_VER "
         [[ -z "$script_desc" ]] && missing+="SCRIPT_DESCRIPTION "
         [[ -z "$script_cat" ]] && missing+="SCRIPT_CATEGORY "
         [[ -z "$check_cmd" ]] && missing+="SCRIPT_CHECK_COMMAND "
+
+        # Check SCRIPT_COMMANDS array exists (for menu integration)
+        if ! grep -q "^SCRIPT_COMMANDS=(" "$script" 2>/dev/null; then
+            missing+="SCRIPT_COMMANDS "
+        fi
 
         if [[ -n "$missing" ]]; then
             echo "  ✗ $name - missing: $missing"
@@ -92,15 +99,19 @@ test_service_scripts_metadata() {
         local missing=""
 
         # Check required fields (all scripts use SCRIPT_* prefix)
+        local script_id=$(grep -m 1 "^SCRIPT_ID=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_name=$(grep -m 1 "^SCRIPT_NAME=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_ver=$(grep -m 1 "^SCRIPT_VER=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_desc=$(grep -m 1 "^SCRIPT_DESCRIPTION=" "$script" 2>/dev/null | cut -d'"' -f2)
         local script_cat=$(grep -m 1 "^SCRIPT_CATEGORY=" "$script" 2>/dev/null | cut -d'"' -f2)
+        local check_cmd=$(grep -m 1 "^SCRIPT_CHECK_COMMAND=" "$script" 2>/dev/null | cut -d'"' -f2)
 
+        [[ -z "$script_id" ]] && missing+="SCRIPT_ID "
         [[ -z "$script_name" ]] && missing+="SCRIPT_NAME "
         [[ -z "$script_ver" ]] && missing+="SCRIPT_VER "
         [[ -z "$script_desc" ]] && missing+="SCRIPT_DESCRIPTION "
         [[ -z "$script_cat" ]] && missing+="SCRIPT_CATEGORY "
+        [[ -z "$check_cmd" ]] && missing+="SCRIPT_CHECK_COMMAND "
 
         # Check SCRIPT_COMMANDS array exists
         if ! grep -q "^SCRIPT_COMMANDS=(" "$script" 2>/dev/null; then

--- a/.devcontainer/manage/dev-setup.sh
+++ b/.devcontainer/manage/dev-setup.sh
@@ -1372,50 +1372,121 @@ show_config_details_and_actions() {
     local config_index=$1
     local config_name="${AVAILABLE_CONFIGS[$config_index]}"
     local config_description="${CONFIG_DESCRIPTIONS[$config_index]}"
+    local script_name="${CONFIG_SCRIPTS[$config_index]}"
+    local script_path="$ADDITIONS_DIR/$script_name"
 
-    # Check if config is configured
-    local is_configured=false
-    if check_config_configured "$config_index"; then
-        is_configured=true
-    fi
+    # Try to extract SCRIPT_COMMANDS array from the script
+    local commands=()
+    while IFS= read -r cmd_def; do
+        commands+=("$cmd_def")
+    done < <(extract_script_commands "$script_path")
 
-    # Build menu based on current state
-    local menu_options=()
-    local status_text
+    # If no SCRIPT_COMMANDS array found, fall back to simple Configure/Back menu
+    if [[ ${#commands[@]} -eq 0 ]]; then
+        # Check if config is configured
+        local is_configured=false
+        if check_config_configured "$config_index"; then
+            is_configured=true
+        fi
 
-    if [[ "$is_configured" = true ]]; then
-        status_text="Status: Configured ✅"
-        menu_options+=("1" "Reconfigure")
-        menu_options+=("2" "Back to configuration list")
-    else
-        status_text="Status: Not configured ❌"
-        menu_options+=("1" "Configure now")
-        menu_options+=("2" "Back to configuration list")
-    fi
+        # Build menu based on current state
+        local menu_options=()
+        local status_text
 
-    # Show config details with available actions
-    local user_choice
-    user_choice=$(dialog --clear \
-        --title "Configuration: $config_name" \
-        --menu "$config_description\n\n$status_text\n\nWhat would you like to do?" \
-        $DIALOG_HEIGHT $DIALOG_WIDTH 6 \
-        "${menu_options[@]}" \
-        2>&1 >/dev/tty)
+        if [[ "$is_configured" = true ]]; then
+            status_text="Status: Configured ✅"
+            menu_options+=("1" "Reconfigure")
+            menu_options+=("2" "Back to configuration list")
+        else
+            status_text="Status: Not configured ❌"
+            menu_options+=("1" "Configure now")
+            menu_options+=("2" "Back to configuration list")
+        fi
 
-    # Handle user choice
-    if [[ $? -ne 0 ]]; then
-        # User pressed ESC - go back
+        # Show config details with available actions
+        local user_choice
+        user_choice=$(dialog --clear \
+            --title "Configuration: $config_name" \
+            --menu "$config_description\n\n$status_text\n\nWhat would you like to do?" \
+            $DIALOG_HEIGHT $DIALOG_WIDTH 6 \
+            "${menu_options[@]}" \
+            2>&1 >/dev/tty)
+
+        # Handle user choice
+        if [[ $? -ne 0 ]]; then
+            # User pressed ESC - go back
+            return 0
+        fi
+
+        case $user_choice in
+            1)
+                execute_config_script "$config_index"
+                ;;
+            2|"")
+                # Go back to config list
+                ;;
+        esac
         return 0
     fi
 
-    case $user_choice in
-        1)
-            execute_config_script "$config_index"
-            ;;
-        2|"")
-            # Go back to config list
-            ;;
-    esac
+    # Show submenu with SCRIPT_COMMANDS (same pattern as show_tool_details_and_confirm)
+    while true; do
+        # Extract additional metadata for display
+        local script_id=$(extract_script_metadata "$script_path" "SCRIPT_ID")
+        local script_ver=$(extract_script_metadata "$script_path" "SCRIPT_VER")
+
+        # Check if configured
+        local config_status="Not configured"
+        if check_config_configured "$config_index"; then
+            config_status="Configured"
+        fi
+
+        # Build info text for menu header
+        local menu_text="ID: $script_id | Version: $script_ver | Status: $config_status\n\n$config_description"
+
+        # Build menu with category prefixes
+        local menu_options=()
+        local menu_actions=()
+        local option_num=1
+
+        for cmd_def in "${commands[@]}"; do
+            IFS='|' read -r category flag description function requires_arg param_prompt <<< "$cmd_def"
+
+            # Add command with category prefix
+            local display_text="[$category] $description"
+            menu_options+=("$option_num" "$display_text")
+            menu_actions[$option_num]="$flag|$requires_arg|$param_prompt"
+            ((option_num++))
+        done
+
+        # Add back option
+        menu_options+=("0" "Back to configuration list")
+
+        # Show submenu
+        local choice
+        choice=$(dialog --clear \
+            --title "$config_name" \
+            --menu "$menu_text" \
+            $DIALOG_HEIGHT $DIALOG_WIDTH $MENU_HEIGHT \
+            "${menu_options[@]}" \
+            2>&1 >/dev/tty)
+
+        # Check if user cancelled (ESC)
+        if [[ $? -ne 0 ]]; then
+            return 0
+        fi
+
+        # Handle back option
+        if [[ $choice -eq 0 || -z "$choice" ]]; then
+            return 0
+        fi
+
+        # Execute selected command
+        local action_def="${menu_actions[$choice]}"
+        if [[ -n "$action_def" ]]; then
+            execute_config_action "$config_index" "$action_def"
+        fi
+    done
 }
 
 execute_config_script() {
@@ -1449,6 +1520,96 @@ execute_config_script() {
 
     echo ""
     read -p "Press Enter to continue..." -r
+}
+
+# Execute a config action based on the SCRIPT_COMMANDS array entry
+# Similar to execute_tool_action() but for config scripts
+# Handles empty flag (default action = run with no arguments)
+execute_config_action() {
+    local config_index=$1
+    local action_def="$2"
+    local config_name="${AVAILABLE_CONFIGS[$config_index]}"
+    local script_name="${CONFIG_SCRIPTS[$config_index]}"
+    local script_path="$ADDITIONS_DIR/$script_name"
+
+    IFS='|' read -r flag requires_arg param_prompt <<< "$action_def"
+
+    # Build command arguments (empty flag = no arguments)
+    local cmd_args=()
+    if [[ -n "$flag" ]]; then
+        cmd_args+=("$flag")
+    fi
+
+    # Prompt for parameter if needed
+    if [[ "$requires_arg" = "true" ]]; then
+        local param_value
+        param_value=$(dialog --clear \
+            --title "Parameter Required" \
+            --inputbox "$param_prompt:" \
+            8 60 \
+            2>&1 >/dev/tty)
+
+        # Check if user cancelled
+        if [[ $? -ne 0 ]]; then
+            return 0
+        fi
+
+        if [[ -n "$param_value" ]]; then
+            cmd_args+=("$param_value")
+        else
+            dialog --msgbox "Parameter required - command cancelled" 6 40
+            clear
+            return 1
+        fi
+    fi
+
+    # Special handling for --help flag (show in dialog)
+    if [[ "$flag" = "--help" ]]; then
+        clear
+        local help_output
+        help_output=$("$script_path" --help 2>&1)
+        dialog --title "$config_name - Help" \
+            --msgbox "$help_output" \
+            $DIALOG_HEIGHT $DIALOG_WIDTH
+        clear
+        return 0
+    fi
+
+    # Log the action
+    local action_desc="${flag:-configure}"
+    log_user_choice "Setup & Configuration" "Action: $config_name $action_desc"
+
+    # Execute command
+    clear
+    if [[ -n "$flag" ]]; then
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "Executing: $script_name ${cmd_args[*]}"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    else
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "Running Configuration: $config_name"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    fi
+    echo ""
+
+    # Make script executable and run
+    chmod +x "$script_path"
+
+    if "$script_path" "${cmd_args[@]}"; then
+        echo ""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "✅ Command completed successfully"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    else
+        echo ""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "❌ Command failed"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    fi
+
+    echo ""
+    read -p "Press Enter to continue..." -r
+    clear
 }
 
 #------------------------------------------------------------------------------

--- a/.devcontainer/manage/dev-setup.sh
+++ b/.devcontainer/manage/dev-setup.sh
@@ -646,9 +646,18 @@ show_all_services_menu() {
             for service_index in "${INDICES[@]}"; do
                 local service_name="${AVAILABLE_SERVICES[$service_index]}"
                 local service_description="${SERVICE_DESCRIPTIONS[$service_index]}"
+                local service_script="${SERVICE_SCRIPTS[$service_index]}"
                 local prefix="${CATEGORY_PREFIX[$category_key]}"
 
-                menu_options+=("$option_num" "$prefix $service_name" "$service_description")
+                # Check if service is running
+                local status_icon=""
+                if bash "$ADDITIONS_DIR/$service_script" --is-running >/dev/null 2>&1; then
+                    status_icon="✅ "
+                else
+                    status_icon="⏸️ "
+                fi
+
+                menu_options+=("$option_num" "$status_icon$prefix $service_name" "$service_description")
                 MENU_TO_SERVICE_INDEX[$option_num]=$service_index
                 ((option_num++))
             done


### PR DESCRIPTION
## Summary

- Add SCRIPT_COMMANDS array and --show flag to all config scripts
- Add SCRIPT_ID requirement to cmd scripts for consistency
- Update service menu to show running/stopped status icons
- Standardize SCRIPT_CATEGORY values across all templates
- Add SERVICE_PRIORITY and SERVICE_DEPENDS to service template
- Add SCRIPT_PREREQUISITES support for config scripts

## Changes

### Config Scripts (6 files)
- Added SCRIPT_ID and SCRIPT_COMMANDS array
- Added `show_config()` function with `--show` flag
- Added case statement for `--show`, `--verify`, `--help` flags
- Fixed `((count++))` causing exit with `set -e`

### Templates (4 files)
- `_template-service-script.sh`: Added SERVICE_PRIORITY, SERVICE_DEPENDS
- `_template-config-script.sh`: Added SCRIPT_PREREQUISITES
- `_template-cmd-script.sh`: Added SCRIPT_ID
- All templates: Updated SCRIPT_CATEGORY to canonical values

### Menu System
- Config scripts now show SCRIPT_COMMANDS menu (like install scripts)
- Service menu shows ✅/⏸️ status icons using --is-running

### Libraries
- `component-scanner.sh`: Added SCRIPT_PREREQUISITES to scan_config_scripts()
- `test-metadata.sh`: Added SCRIPT_ID requirement for cmd scripts

## Test plan
- [x] Static tests pass (18/18)
- [x] Manual testing of config --show, --verify, --help flags
- [x] Manual testing of service status icons in menu
- [x] Manual testing of dev-setup menu navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies script metadata and categories, adds SCRIPT_COMMANDS/flags and prerequisites, surfaces service running status in menus, and updates scanners/tests to support the new contracts.
> 
> - **Templates**:
>   - Standardize categories; add `SCRIPT_ID` for `cmd` template; add `SERVICE_PRIORITY`/`SERVICE_DEPENDS` to service template; add `SCRIPT_PREREQUISITES` and default `SCRIPT_COMMANDS` to config template; set install template category to `LANGUAGE_DEV`.
> - **Config Scripts** (`config-*.sh`):
>   - Add `SCRIPT_ID`, `SCRIPT_COMMANDS`, and `--show`/`--verify`/`--help` handlers; implement `show_config()` and verification logic; declare prerequisites where applicable (e.g., `config-ai-claudecode.sh` depends on `config-nginx.sh`).
> - **Service Scripts** (`service-*.sh`):
>   - Add `SCRIPT_CHECK_COMMAND`, priorities/depends metadata, and `--is-running`; expand command sets; integrate with supervisord expectations.
> - **Menu System** (`dev-setup.sh`):
>   - Show service status icons (✅/⏸️) via `--is-running`; add config submenus powered by `SCRIPT_COMMANDS`; implement `execute_config_action()`.
> - **Libraries/Tests**:
>   - `component-scanner.sh`: include `SCRIPT_PREREQUISITES` in config scan; expose unified extractors.
>   - Static tests: require `SCRIPT_ID` and `SCRIPT_COMMANDS` for all script types; validate service `SCRIPT_CHECK_COMMAND`.
> - **Misc**:
>   - `cmd-ai.sh` adds `SCRIPT_ID` and command definitions.
>   - Rust installer: replace VS Code "Crates" extension with "Dependi".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa9711473413eef3ccefb435f10ad238da1b9f8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->