### PR TITLE
docs: update contributor documentation for accuracy

### DIFF
--- a/docs/ai-developer/WORKFLOW.md
+++ b/docs/ai-developer/WORKFLOW.md
@@ -166,8 +166,7 @@ Claude will:
    > - Current version: 1.0.3
    > - If yes, what should the new version be?"
 
-7. **Check documentation** (if install scripts changed):
-   > "Install scripts were modified. I'll run `dev-docs` to update the documentation."
+7. **Documentation**: CI auto-updates docs after merge - no manual step needed.
 
 See [CI-CD.md](../contributors/CI-CD.md) for details on what happens after merge.
 

--- a/docs/ai-developer/plans/completed/PLAN-dynamic-dev-help.md
+++ b/docs/ai-developer/plans/completed/PLAN-dynamic-dev-help.md
@@ -7,7 +7,7 @@
 
 # Plan: Dynamic dev-help Command List
 
-## Status: READY FOR IMPLEMENTATION
+## Status: COMPLETED
 
 **Goal**: Replace static command list in `dev-help` with dynamically generated list using existing `scan_manage_scripts` function.
 

--- a/docs/contributors/RELEASING.md
+++ b/docs/contributors/RELEASING.md
@@ -2,15 +2,7 @@
 
 How to create and publish new versions of devcontainer-toolbox.
 
-## Before Releasing
-
-If any install scripts were added or modified, regenerate the tools documentation:
-
-```bash
-dev-docs
-```
-
-This updates `docs/tools.md` with current script information.
+**See also:** [CI-CD.md](CI-CD.md) for the full workflow diagram and details.
 
 ---
 
@@ -46,15 +38,16 @@ git push
 
 ### 3. Automatic Release
 
-When you push to `main`, GitHub Actions automatically:
+When you merge a PR to `main`, GitHub Actions automatically:
 
 1. Runs CI tests (`.github/workflows/ci-tests.yml`)
-2. If tests pass, creates a release (`.github/workflows/zip_dev_setup.yml`):
+2. Auto-updates documentation if needed (commits directly to main)
+3. If tests pass, creates a release (`.github/workflows/zip_dev_setup.yml`):
    - Reads version from `version.txt`
    - Creates `.devcontainer/.version` file with `VERSION=1.0.4`
    - Updates `devcontainer.json` with the version (triggers VS Code rebuild prompt)
-   - Packages everything into `dev_setup.zip`
-   - Creates GitHub release tagged with the version
+   - Packages everything into `dev_containers.zip`
+   - Creates GitHub release tagged "latest"
 
 ---
 
@@ -73,9 +66,11 @@ Use semantic versioning: `MAJOR.MINOR.PATCH`
 ## How Updates Reach Users
 
 ```
-You push to main
+You merge PR to main
        ↓
-GitHub Actions creates release with dev_setup.zip
+CI Tests run → If pass → Release workflow runs
+       ↓
+GitHub creates release with dev_containers.zip
        ↓
 User runs `dev-update` in their container
        ↓
@@ -85,6 +80,8 @@ Compares with local .devcontainer/.version
        ↓
 If newer: downloads and installs update
 ```
+
+For the full two-stage workflow (PR validation vs. release), see [CI-CD.md](CI-CD.md).
 
 ---
 

--- a/docs/contributors/adding-tools.md
+++ b/docs/contributors/adding-tools.md
@@ -38,7 +38,7 @@ SCRIPT_CHECK_COMMAND="command -v mytool >/dev/null 2>&1"
 .devcontainer/additions/install-mytool.sh --help
 .devcontainer/additions/install-mytool.sh
 
-# 4. Update docs
+# 4. (Optional) Preview docs locally - CI auto-updates after merge
 dev-docs
 ```
 
@@ -146,10 +146,10 @@ dev-setup
 .devcontainer/additions/install-mytool.sh --uninstall
 
 # Run automated tests
-.devcontainer/additions/tests/run-all-tests.sh static install-mytool.sh
+dev-test static install-mytool.sh
 
-# Run shellcheck
-shellcheck .devcontainer/additions/install-mytool.sh
+# Run shellcheck (included in dev-test lint)
+dev-test lint
 ```
 
 See [testing.md](testing.md) for more details on the test framework.
@@ -168,13 +168,13 @@ Some documentation files live alongside code (not in `docs/`) because they're me
 
 ## After Adding a Script
 
-Regenerate documentation (run inside the devcontainer):
+Documentation is **auto-updated by CI** after you merge your PR. No manual step needed.
+
+To preview docs locally before merging:
 
 ```bash
 dev-docs
 ```
-
-This updates `docs/tools.md` so users can see the new tool.
 
 ---
 
@@ -189,8 +189,8 @@ This updates `docs/tools.md` so users can see the new tool.
 
 3. **Make your changes:**
    - Add your script
-   - Run tests: `.devcontainer/additions/tests/run-all-tests.sh static`
-   - Regenerate docs: `dev-docs`
+   - Run tests: `dev-test static`
+   - (Optional) Preview docs: `dev-docs` - CI auto-updates after merge
 
 4. **Commit and push:**
    ```bash

--- a/docs/contributors/manage-scripts.md
+++ b/docs/contributors/manage-scripts.md
@@ -100,7 +100,7 @@ The `dev-setup` main menu is dynamically generated:
    chmod +x .devcontainer/manage/dev-newcmd.sh
    ```
 
-4. Regenerate documentation:
+4. Documentation is auto-updated by CI after merge. To preview locally:
    ```bash
    dev-docs
    ```

--- a/docs/contributors/testing.md
+++ b/docs/contributors/testing.md
@@ -9,17 +9,18 @@ Automated tests for validating install scripts, config scripts, and libraries.
 ## Quick Start
 
 ```bash
-# Run all tests (static + unit)
-.devcontainer/additions/tests/run-all-tests.sh
+# Run all tests (static + unit + lint)
+dev-test
 
 # Run specific test level
-.devcontainer/additions/tests/run-all-tests.sh static    # Fast, no execution
-.devcontainer/additions/tests/run-all-tests.sh unit      # Safe execution (--help, --verify)
-.devcontainer/additions/tests/run-all-tests.sh install   # Full install/uninstall cycle (slow)
+dev-test static    # Fast, no execution
+dev-test unit      # Safe execution (--help, --verify)
+dev-test install   # Full install/uninstall cycle (slow)
+dev-test lint      # ShellCheck linting
 
 # Test a specific script
-.devcontainer/additions/tests/run-all-tests.sh static install-dev-python.sh
-.devcontainer/additions/tests/run-all-tests.sh install install-dev-python.sh
+dev-test static install-dev-python.sh
+dev-test install install-dev-python.sh
 ```
 
 ---
@@ -63,13 +64,13 @@ When creating new scripts, run tests to validate:
 ```bash
 # 1. Create script following template
 # 2. Run static tests
-.devcontainer/additions/tests/run-all-tests.sh static install-dev-newlang.sh
+dev-test static install-dev-newlang.sh
 
 # 3. Run unit tests
-.devcontainer/additions/tests/run-all-tests.sh unit install-dev-newlang.sh
+dev-test unit install-dev-newlang.sh
 
 # 4. Run install cycle test
-.devcontainer/additions/tests/run-all-tests.sh install install-dev-newlang.sh
+dev-test install install-dev-newlang.sh
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Updated CI-CD.md with clearer two-stage workflow diagram
- Fixed RELEASING.md to reference correct zip filename and link to CI-CD
- Updated testing.md and adding-tools.md to use `dev-test` command
- Added notes about CI auto-updating docs to manage-scripts.md, adding-tools.md, WORKFLOW.md
- Moved completed dynamic-dev-help plan to completed/ folder

## Test plan
- [x] Documentation reads correctly
- [ ] Links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Contributor docs refresh**
> 
> - Clarifies CI/CD with a two-stage PR→release diagram, updates triggers, and emphasizes no releases on PRs
> - Updates releasing details: corrects zip name to `dev_containers.zip`, links to CI-CD, and specifies merge-to-main trigger; CI now auto-updates docs
> - Standardizes testing instructions to `dev-test` (adds `lint`), updates `adding-tools.md`, `manage-scripts.md`, and `testing.md`
> - Revises `WORKFLOW.md` to state documentation is auto-updated by CI after merge (no manual `dev-docs` step)
> - Moves `PLAN-dynamic-dev-help.md` to `plans/completed/` and marks status as COMPLETED
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21eb7a7b18e776370eb721ebe83b17d478a0f434. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->