### PR TITLE
fix: use useBaseUrl for AI demo GIF path

### DIFF
--- a/website/src/components/AiDemo/index.tsx
+++ b/website/src/components/AiDemo/index.tsx
@@ -1,5 +1,6 @@
 import type {ReactNode} from 'react';
 import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './styles.module.css';
 
 export default function AiDemo(): ReactNode {
@@ -12,7 +13,7 @@ export default function AiDemo(): ReactNode {
         </p>
         <div className={styles.gifContainer}>
           <img
-            src="/devcontainer-toolbox/img/ai-implement-plan-teaser.gif"
+            src={useBaseUrl('/img/ai-implement-plan-teaser.gif')}
             alt="AI implementing a plan"
             className={styles.demoGif}
           />


### PR DESCRIPTION
## Summary
- Fixes the AI demo GIF not loading on the live site
- The path was hardcoded to `/devcontainer-toolbox/` which was the old baseUrl
- Now uses `useBaseUrl` hook to handle the path correctly for the custom domain

## Test plan
- [ ] GIF loads on homepage at dct.sovereignsky.no after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)