### PR TITLE
fix: trigger docs deploy on version.txt changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'website/**'
+      - 'version.txt'
       - '.devcontainer/additions/**'
       - '.devcontainer/manage/dev-logos.sh'
       - '.devcontainer/manage/dev-docs.sh'


### PR DESCRIPTION
## Summary

- Add `version.txt` to deploy-docs workflow path triggers
- The website reads version from version.txt at build time, but version bumps didn't trigger a docs rebuild, leaving the site showing stale versions

## Test plan

- [ ] After merge, docs site at dct.sovereignsky.no shows v1.6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just broadens the GitHub Actions path filter to ensure docs rebuilds run when the version file updates.
> 
> **Overview**
> Ensures the documentation GitHub Pages deployment runs when `version.txt` is updated by adding it to the `deploy-docs.yml` push `paths` filter, so version bumps trigger a site rebuild and redeploy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad4a538a910376db40f49cb0187e3ffd03e4a332. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->