### PR TITLE
fix: use cmd.exe-compatible initializeCommand on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -83,9 +83,9 @@ $devcontainerJson = @'
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
 
     // Capture host git identity before container starts.
-    // Uses "bash -c" so it works on both bash (macOS/Linux) and PowerShell (Windows).
-    // On Windows, bash is available via Git for Windows or WSL.
-    "initializeCommand": "bash -c 'mkdir -p .devcontainer.secrets/env-vars && (git config --global user.name > .devcontainer.secrets/env-vars/.git-host-name 2>/dev/null || true) && (git config --global user.email > .devcontainer.secrets/env-vars/.git-host-email 2>/dev/null || true)'",
+    // Uses cmd.exe syntax since VS Code on Windows runs initializeCommand via cmd.exe.
+    // If git is not installed, the commands silently fail — entrypoint has fallbacks.
+    "initializeCommand": "mkdir .devcontainer.secrets\\env-vars 2>nul & git config --global user.name > .devcontainer.secrets\\env-vars\\.git-host-name 2>nul & git config --global user.email > .devcontainer.secrets\\env-vars\\.git-host-email 2>nul",
 
     "remoteUser": "vscode",
     "containerUser": "vscode",

--- a/install.sh
+++ b/install.sh
@@ -79,10 +79,8 @@ cat > .devcontainer/devcontainer.json << 'DEVCONTAINER_EOF'
     "workspaceFolder": "/workspace",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
 
-    // Capture host git identity before container starts.
-    // Uses "bash -c" so it works on both bash (macOS/Linux) and PowerShell (Windows).
-    // On Windows, bash is available via Git for Windows or WSL.
-    "initializeCommand": "bash -c 'mkdir -p .devcontainer.secrets/env-vars && (git config --global user.name > .devcontainer.secrets/env-vars/.git-host-name 2>/dev/null || true) && (git config --global user.email > .devcontainer.secrets/env-vars/.git-host-email 2>/dev/null || true)'",
+    // Capture host git identity before container starts
+    "initializeCommand": "mkdir -p .devcontainer.secrets/env-vars && (git config --global user.name > .devcontainer.secrets/env-vars/.git-host-name 2>/dev/null || true) && (git config --global user.email > .devcontainer.secrets/env-vars/.git-host-email 2>/dev/null || true)",
 
     "remoteUser": "vscode",
     "containerUser": "vscode",


### PR DESCRIPTION
## Summary

- Use platform-specific `initializeCommand` in each install script: bash syntax for Mac/Linux, cmd.exe syntax for Windows
- Revert `install.sh` to original form (the `bash -c` wrapper from PR #32 was unnecessary on Mac/Linux)

Fixes #33

## Test plan

- [ ] Windows tester: run `install.ps1`, open project in VS Code, verify container starts without `initializeCommand` error
- [ ] Verify git identity is captured (check `.devcontainer.secrets/env-vars/.git-host-name` exists after startup)
- [ ] Mac/Linux: verify `install.sh` still works (reverted to original bash syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)