### PR TITLE
fix: force exit code 0 in Windows initializeCommand

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -85,7 +85,7 @@ $devcontainerJson = @'
     // Capture host git identity before container starts.
     // Uses cmd.exe syntax since VS Code on Windows runs initializeCommand via cmd.exe.
     // If git is not installed, the commands silently fail — entrypoint has fallbacks.
-    "initializeCommand": "mkdir .devcontainer.secrets\\env-vars 2>nul & git config --global user.name > .devcontainer.secrets\\env-vars\\.git-host-name 2>nul & git config --global user.email > .devcontainer.secrets\\env-vars\\.git-host-email 2>nul",
+    "initializeCommand": "mkdir .devcontainer.secrets\\env-vars 2>nul & git config --global user.name > .devcontainer.secrets\\env-vars\\.git-host-name 2>nul & git config --global user.email > .devcontainer.secrets\\env-vars\\.git-host-email 2>nul & ver >nul",
 
     "remoteUser": "vscode",
     "containerUser": "vscode",


### PR DESCRIPTION
## Summary

- Append `ver >nul` to the Windows `initializeCommand` to force exit code 0
- Previous fix (PR #35) fixed the cmd.exe syntax but the command still failed because `git config` returns exit code 1 when not configured, and cmd.exe uses the last command's exit code

Fixes #33

## Test plan

- [ ] Windows tester: delete existing `.devcontainer/`, re-run `install.ps1`, open in VS Code, verify container starts
- [ ] Verify the `initializeCommand` line in the log shows `& ver >nul` at the end
- [ ] Mac/Linux: no changes to `install.sh`, still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)