### PR TITLE
fix: remove Docker socket mount from Windows template

### DIFF
--- a/.devcontainer/manage/dev-update.sh
+++ b/.devcontainer/manage/dev-update.sh
@@ -77,15 +77,28 @@ fi
 
 # ─── Pull the latest image ───────────────────────────────────────────────────
 
-echo ""
-echo "Pulling image: $IMAGE"
-# Use sudo because the Docker socket GID from the host may not match
-# the container's docker group GID
-sudo docker pull "$IMAGE"
+# Check if Docker is available inside the container (requires socket mount)
+if sudo docker info &>/dev/null; then
+    echo ""
+    echo "Pulling image: $IMAGE"
+    sudo docker pull "$IMAGE"
 
-echo ""
-echo "✅ Image updated!"
-echo ""
-echo "🔄 Rebuild the container to apply the update:"
-echo "   VS Code: Cmd/Ctrl+Shift+P > 'Dev Containers: Rebuild Container'"
-echo ""
+    echo ""
+    echo "✅ Image updated!"
+    echo ""
+    echo "🔄 Rebuild the container to apply the update:"
+    echo "   VS Code: Cmd/Ctrl+Shift+P > 'Dev Containers: Rebuild Container'"
+    echo ""
+else
+    # Docker socket not mounted (typical on Windows where /var/run/docker.sock
+    # doesn't exist on the host). Give the user a command to run on the host.
+    echo ""
+    echo "Docker is not available inside this container."
+    echo "To update, run this in your host terminal (PowerShell or CMD):"
+    echo ""
+    echo "  docker pull $IMAGE"
+    echo ""
+    echo "Then rebuild the container:"
+    echo "  VS Code: Cmd/Ctrl+Shift+P > 'Dev Containers: Rebuild Container'"
+    echo ""
+fi

--- a/install.ps1
+++ b/install.ps1
@@ -70,14 +70,13 @@ $devcontainerJson = @'
     },
 
     "remoteEnv": {
-        "DOCKER_HOST": "unix:///var/run/docker.sock",
         "DCT_HOME": "/opt/devcontainer-toolbox",
         "DCT_WORKSPACE": "/workspace"
     },
 
-    "mounts": [
-        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached"
-    ],
+    // Docker socket mount is not included on Windows because /var/run/docker.sock
+    // does not exist on the Windows host (Docker runs inside WSL2).
+    // dev-update will instruct you to run 'docker pull' from your host terminal instead.
 
     "workspaceFolder": "/workspace",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -27,6 +27,17 @@ Extension ID: ms-vscode-remote.remote-containers
 
 **Solution:** Start Docker/Rancher Desktop and try again.
 
+### Windows: "A mount config is invalid"
+
+**Symptom:** Container fails to start with "A mount config is invalid. Make sure it has the right format and a secure folder that exists on the machine where Docker daemon is running."
+
+**Cause:** This happens when `devcontainer.json` includes a Docker socket mount (`/var/run/docker.sock`) that doesn't exist on the Windows host. On Windows, the Docker daemon runs inside WSL2.
+
+**Solution:** Re-run the Windows install command in your project folder to get an updated `devcontainer.json`:
+```powershell
+irm https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.ps1 | iex
+```
+
 ---
 
 ## Git Issues
@@ -128,6 +139,16 @@ dev-services enable <service-name>
 ### dev-update permission denied
 
 **Solution:** Run with sudo if needed, or check file permissions.
+
+### Windows: dev-update says "Docker is not available"
+
+**This is expected on Windows.** The Docker socket isn't mounted inside the container on Windows. `dev-update` will show you the exact command to run in your host terminal:
+
+```powershell
+docker pull ghcr.io/terchris/devcontainer-toolbox:latest
+```
+
+Then rebuild the container: `Ctrl+Shift+P` → "Dev Containers: Rebuild Container"
 
 ### Update not applying
 


### PR DESCRIPTION
## Summary

- Remove Docker socket mount (`/var/run/docker.sock`) from the Windows `install.ps1` template — this path doesn't exist on the Windows host since Docker runs inside WSL2
- Update `dev-update` to detect missing Docker socket and show a copy-pasteable host command instead of failing
- Add Windows-specific troubleshooting docs for the mount error and `dev-update` behavior

## Context

On Windows with Rancher Desktop, the Docker daemon runs inside a WSL2 VM. The socket `/var/run/docker.sock` exists inside that WSL distro, but VS Code validates bind mount paths from the Windows host perspective, causing: "A mount config is invalid."

The Mac/Linux template (`install.sh`) is unchanged — the socket mount works fine there.

## User experience

**Mac/Linux `dev-update`** (unchanged): pulls image directly inside container.

**Windows `dev-update`** (new):
```
$ dev-update
Checking for updates...
Current version: 1.6.4
Latest version:  1.7.0
Update available: 1.6.4 → 1.7.0

Docker is not available inside this container.
To update, run this in your host terminal (PowerShell or CMD):

  docker pull ghcr.io/terchris/devcontainer-toolbox:latest

Then rebuild the container:
  VS Code: Cmd/Ctrl+Shift+P > 'Dev Containers: Rebuild Container'
```

## Test plan

- [ ] Windows: Run `install.ps1`, verify container starts without mount error
- [ ] Windows: Run `dev-update` inside container, verify it shows host command
- [ ] Mac/Linux: Run `install.sh`, verify Docker socket mount still works
- [ ] Mac/Linux: Run `dev-update`, verify it still pulls image directly

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)