### PR TITLE
fix: hide contributor tools from dev-help, add --all flag

### DIFF
--- a/.devcontainer/manage/dev-help.sh
+++ b/.devcontainer/manage/dev-help.sh
@@ -10,6 +10,23 @@ SCRIPT_DESCRIPTION="Show available commands and version info"
 SCRIPT_CATEGORY="SYSTEM_COMMANDS"
 SCRIPT_CHECK_COMMAND="true"
 
+# Parse arguments
+SHOW_ALL=false
+if [ "$1" = "--all" ] || [ "$1" = "-a" ]; then
+    SHOW_ALL=true
+fi
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    echo "Usage: dev-help [OPTIONS]"
+    echo ""
+    echo "Show available commands and version info."
+    echo ""
+    echo "Options:"
+    echo "  -a, --all     Show all commands including contributor tools"
+    echo "  -h, --help    Show this help message"
+    exit 0
+fi
+
 # Get script directory and source utilities
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
@@ -59,13 +76,23 @@ done < <(scan_manage_scripts "$MANAGE_DIR")
 # Add dev-setup (excluded from scanner to avoid recursion)
 system_cmds+=("$(printf "  %-14s %s" "dev-setup" "Interactive menu for installing tools and managing services")")
 
-# Output system commands first, then contributor tools
+# Output system commands
 for cmd in "${system_cmds[@]}"; do
     echo "$cmd"
 done
-for cmd in "${contrib_cmds[@]}"; do
-    echo "$cmd"
-done
+
+# Show contributor tools only with --all flag
+if [ "$SHOW_ALL" = true ] && [ ${#contrib_cmds[@]} -gt 0 ]; then
+    echo ""
+    echo "Contributor tools:"
+    for cmd in "${contrib_cmds[@]}"; do
+        echo "$cmd"
+    done
+fi
 
 echo ""
+echo "Configuration commands are available via: dev-setup → Manage Configurations"
 echo "Run any command with --help for more details."
+if [ "$SHOW_ALL" = false ] && [ ${#contrib_cmds[@]} -gt 0 ]; then
+    echo "Use 'dev-help --all' to include contributor tools."
+fi

--- a/.devcontainer/manage/dev-logos.sh
+++ b/.devcontainer/manage/dev-logos.sh
@@ -18,6 +18,15 @@
 # Install prerequisites with: bash .devcontainer/additions/install-dev-imagetools.sh
 #
 
+#------------------------------------------------------------------------------
+# Script Metadata (for component scanner)
+#------------------------------------------------------------------------------
+SCRIPT_ID="dev-logos"
+SCRIPT_NAME="Logos"
+SCRIPT_DESCRIPTION="Process logo images to production-ready WebP format"
+SCRIPT_CATEGORY="CONTRIBUTOR_TOOLS"
+SCRIPT_CHECK_COMMAND="command -v convert"
+
 set -e
 
 # Determine workspace root


### PR DESCRIPTION
## Summary

- Add metadata to `dev-logos.sh` so it's discoverable by the component scanner
- Hide contributor tools (dev-cubes, dev-docs, dev-logos, dev-test) from default `dev-help` output
- Add `--all` flag to show contributor tools: `dev-help --all`
- Add hint about config commands available via `dev-setup`

## User experience

**`dev-help`** (default — clean for regular users):
```
Available dev-* commands:

  dev-check      Configure and validate Git identity and credentials
  dev-env        Show installed tools and environment info
  dev-help       Show available commands and version info
  dev-log        Display the container startup log
  dev-services   Manage background services (start, stop, status, logs)
  dev-template   Create project files from templates
  dev-update     Update devcontainer-toolbox to latest version
  dev-setup      Interactive menu for installing tools and managing services

Configuration commands are available via: dev-setup → Manage Configurations
Run any command with --help for more details.
Use 'dev-help --all' to include contributor tools.
```

**`dev-help --all`** (for contributors):
```
  ...

Contributor tools:
  dev-cubes      Generate homepage floating cubes configuration
  dev-docs       Generate documentation (tools.md, commands.md)
  dev-logos      Process logo images to production-ready WebP format
  dev-test       Run static, unit, and install tests
```

## Test plan

- [ ] `dev-help` shows only system commands
- [ ] `dev-help --all` shows system + contributor tools
- [ ] `dev-help --help` shows usage info
- [ ] dev-logos appears in `dev-help --all`

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)