### PR TITLE
fix: update all references from terchris to helpers-no

### DIFF
--- a/.devcontainer/additions/install-dev-ai-claudecode.sh
+++ b/.devcontainer/additions/install-dev-ai-claudecode.sh
@@ -11,7 +11,7 @@
 # Script metadata - must be at the very top of the configuration section
 SCRIPT_NAME="Claude Code"
 SCRIPT_ID="dev-ai-claudecode"
-SCRIPT_VER="0.0.2"
+SCRIPT_VER="0.0.3"
 SCRIPT_DESCRIPTION="Installs Claude Code, Anthropic's terminal-based AI coding assistant with agentic capabilities and LSP integration"
 SCRIPT_CATEGORY="AI_TOOLS"
 SCRIPT_CHECK_COMMAND="[ -f /home/vscode/.local/bin/claude ] || command -v claude >/dev/null 2>&1"
@@ -95,7 +95,7 @@ PACKAGES_SYSTEM=(
 )
 
 # Note: We use native installation instead of npm to enable auto-updates
-# See: https://github.com/terchris/devcontainer-toolbox/issues/41
+# See: https://github.com/helpers-no/devcontainer-toolbox/issues/41
 PACKAGES_NODE=()
 
 PACKAGES_PYTHON=()

--- a/.devcontainer/additions/lib/git-identity.sh
+++ b/.devcontainer/additions/lib/git-identity.sh
@@ -20,8 +20,8 @@
 #                   git@ssh.dev.azure.com:v3/org/project/repo
 #   - Generic: Falls back to extracting last path component
 #
-# Usage: parse_git_remote_url "https://github.com/terchris/devcontainer-toolbox.git"
-# After: GIT_PROVIDER="github", GIT_ORG="terchris", GIT_REPO="devcontainer-toolbox"
+# Usage: parse_git_remote_url "https://github.com/helpers-no/devcontainer-toolbox.git"
+# After: GIT_PROVIDER="github", GIT_ORG="helpers-no", GIT_REPO="devcontainer-toolbox"
 #
 parse_git_remote_url() {
     local url="$1"

--- a/.devcontainer/manage/dev-sync.sh
+++ b/.devcontainer/manage/dev-sync.sh
@@ -15,7 +15,7 @@ set -e
 
 DCT_HOME="${DCT_HOME:-/opt/devcontainer-toolbox}"
 MANAGE_DIR="$DCT_HOME/manage"
-REPO="terchris/devcontainer-toolbox"
+REPO="helpers-no/devcontainer-toolbox"
 BACKUP_DIR="$DCT_HOME/.backup"
 
 # Source version-utils for centralized version checking

--- a/.devcontainer/manage/dev-template.sh
+++ b/.devcontainer/manage/dev-template.sh
@@ -107,7 +107,7 @@ function display_intro() {
 # Download templates repository as zip
 #------------------------------------------------------------------------------
 function download_templates() {
-  local template_owner="terchris"
+  local template_owner="helpers-no"
   local template_repo="urbalurba-dev-templates"
   local template_branch="main"
   local zip_url="https://github.com/$template_owner/$template_repo/archive/refs/heads/$template_branch.zip"

--- a/.devcontainer/manage/dev-update.sh
+++ b/.devcontainer/manage/dev-update.sh
@@ -18,7 +18,7 @@ if [ -n "$DCT_HOME" ] && [ -f "$DCT_HOME/additions/lib/ensure-gitignore.sh" ]; t
     source "$DCT_HOME/additions/lib/ensure-gitignore.sh"
 fi
 
-REPO="terchris/devcontainer-toolbox"
+REPO="helpers-no/devcontainer-toolbox"
 IMAGE="ghcr.io/$REPO:latest"
 
 # Parse arguments

--- a/.devcontainer/manage/lib/version-utils.sh
+++ b/.devcontainer/manage/lib/version-utils.sh
@@ -38,7 +38,7 @@ _load_version_info() {
     # Image mode: version.txt is inside $DCT_HOME (not in parent dir)
     elif [ -n "$DCT_HOME" ] && [ -f "$DCT_HOME/version.txt" ]; then
         TOOLBOX_VERSION=$(cat "$DCT_HOME/version.txt" 2>/dev/null | tr -d '[:space:]')
-        TOOLBOX_REPO="terchris/devcontainer-toolbox"
+        TOOLBOX_REPO="helpers-no/devcontainer-toolbox"
     # Copy mode: version.txt in workspace root (parent of .devcontainer/)
     elif [ -f "$version_txt" ]; then
         TOOLBOX_VERSION=$(cat "$version_txt" 2>/dev/null | tr -d '[:space:]')

--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,9 @@ Cargo.lock
 composer.phar
 vendor/
 
-# Personal working directory (never commit)
+# Personal working directories (never commit)
 personal/
+terchris/
 
 # Devcontainer secrets folder - contains credentials (NEVER commit)
 .devcontainer.secrets/

--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,8 @@ Cargo.lock
 composer.phar
 vendor/
 
-# Terchris personal working directory (never commit)
-terchris/
+# Personal working directory (never commit)
+personal/
 
 # Devcontainer secrets folder - contains credentials (NEVER commit)
 .devcontainer.secrets/

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Stop wasting time setting up development environments. DevContainer Toolbox give
 
 ```bash
 # Mac/Linux
-curl -fsSL https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.sh | bash
 
 # Windows PowerShell
-irm https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.ps1 | iex
 ```
 
 This creates a single `devcontainer.json` and pulls the pre-built container image.

--- a/devcontainer-user-template.json
+++ b/devcontainer-user-template.json
@@ -1,6 +1,6 @@
 {
     // DevContainer Toolbox — image mode template for USER PROJECTS
-    // Docs: https://github.com/terchris/devcontainer-toolbox
+    // Docs: https://github.com/helpers-no/devcontainer-toolbox
     //
     // This file is the SINGLE SOURCE OF TRUTH for user project configuration.
     // All install scripts and deployment tools download this file.
@@ -8,7 +8,7 @@
     //
     // overrideCommand: false is REQUIRED so VS Code doesn't bypass the ENTRYPOINT.
     // The entrypoint handles all startup — no lifecycle hooks needed.
-    "image": "ghcr.io/terchris/devcontainer-toolbox:latest",
+    "image": "ghcr.io/helpers-no/devcontainer-toolbox:latest",
     "overrideCommand": false,
 
     // VPN capabilities

--- a/install.ps1
+++ b/install.ps1
@@ -1,11 +1,11 @@
 # install.ps1 - First-time install of devcontainer-toolbox (image mode)
-# Run with: irm https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.ps1 | iex
-# If blocked: powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.ps1 | iex"
+# Run with: irm https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.ps1 | iex
+# If blocked: powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.ps1 | iex"
 
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-$repo = "terchris/devcontainer-toolbox"
+$repo = "helpers-no/devcontainer-toolbox"
 $image = "ghcr.io/${repo}:latest"
 $templateUrl = "https://raw.githubusercontent.com/$repo/main/devcontainer-user-template.json"
 

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # install.sh - First-time install of devcontainer-toolbox (image mode)
-# Run with: curl -fsSL https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.sh | bash
+# Run with: curl -fsSL https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.sh | bash
 set -e
 
-REPO="terchris/devcontainer-toolbox"
+REPO="helpers-no/devcontainer-toolbox"
 IMAGE="ghcr.io/$REPO:latest"
 TEMPLATE_URL="https://raw.githubusercontent.com/$REPO/main/devcontainer-user-template.json"
 

--- a/website/README.md
+++ b/website/README.md
@@ -47,7 +47,7 @@ The site uses environment variables for GitHub URLs, so it works on any fork wit
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GITHUB_ORG` | `terchris` | GitHub organization/username |
+| `GITHUB_ORG` | `helpers-no` | GitHub organization/username |
 | `GITHUB_REPO` | `devcontainer-toolbox` | Repository name |
 
 **How it works:**

--- a/website/blog/2026-01-18-why-devcontainer-toolbox-exists/index.md
+++ b/website/blog/2026-01-18-why-devcontainer-toolbox-exists/index.md
@@ -70,7 +70,7 @@ DevContainer Toolbox contributes to this goal by providing development tools tha
 Adding DevContainer Toolbox to your project takes one command:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.sh | bash
 ```
 
 Then open your project in VS Code and click "Reopen in Container."
@@ -79,4 +79,4 @@ Your development environment is now local, reproducible, and sovereign.
 
 ---
 
-*DevContainer Toolbox is open source and welcomes contributions. Visit our [GitHub repository](https://github.com/terchris/devcontainer-toolbox) to get involved.*
+*DevContainer Toolbox is open source and welcomes contributions. Visit our [GitHub repository](https://github.com/helpers-no/devcontainer-toolbox) to get involved.*

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -7,5 +7,5 @@ terchris:
 dct-team:
   name: DCT Team
   title: DevContainer Toolbox Contributors
-  url: https://github.com/terchris/devcontainer-toolbox
+  url: https://github.com/helpers-no/devcontainer-toolbox
   image_url: https://github.com/terchris.png

--- a/website/docs/about.md
+++ b/website/docs/about.md
@@ -70,10 +70,10 @@ DevContainer Toolbox works with VS Code and GitHub Codespaces. Add it to any pro
 
 ```bash
 # Mac/Linux
-curl -fsSL https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.sh | bash
 
 # Windows PowerShell
-irm https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.ps1 | iex
 ```
 
 Then open in VS Code and click "Reopen in Container."
@@ -84,6 +84,6 @@ Then open in VS Code and click "Reopen in Container."
 
 ## Connect With Us
 
-- **GitHub**: [devcontainer-toolbox](https://github.com/terchris/devcontainer-toolbox)
+- **GitHub**: [devcontainer-toolbox](https://github.com/helpers-no/devcontainer-toolbox)
 - **SovereignSky**: [sovereignsky.no](https://sovereignsky.no)
 - **helpers.no**: [helpers.no](https://helpers.no)

--- a/website/docs/ai-development/ai-developer/README.md
+++ b/website/docs/ai-development/ai-developer/README.md
@@ -73,4 +73,4 @@ plans/
 ## Related Documentation
 
 - [Contributor docs](../../contributors/) - Technical documentation for human developers
-- [CLAUDE.md](https://github.com/terchris/devcontainer-toolbox/blob/main/CLAUDE.md) - Project-specific Claude Code instructions (in repo root)
+- [CLAUDE.md](https://github.com/helpers-no/devcontainer-toolbox/blob/main/CLAUDE.md) - Project-specific Claude Code instructions (in repo root)

--- a/website/docs/ai-development/ai-developer/plans/active/PLAN-dev-template-placeholder-fix.md
+++ b/website/docs/ai-development/ai-developer/plans/active/PLAN-dev-template-placeholder-fix.md
@@ -12,7 +12,7 @@
 
 **Last Updated**: 2026-03-04
 
-**Investigation**: [INVESTIGATE-dev-template-placeholder-substitution.md](INVESTIGATE-dev-template-placeholder-substitution.md)
+**Investigation**: [INVESTIGATE-dev-template-placeholder-substitution.md](../completed/INVESTIGATE-dev-template-placeholder-substitution.md)
 
 ---
 

--- a/website/docs/ai-development/ai-developer/plans/active/PLAN-transfer-to-helpers-no.md
+++ b/website/docs/ai-development/ai-developer/plans/active/PLAN-transfer-to-helpers-no.md
@@ -32,7 +32,7 @@ The repo lives under `terchris/devcontainer-toolbox` but needs to be under the `
 
 ---
 
-## Phase 1: Create branch and fix references — IN PROGRESS
+## Phase 1: Create branch and fix references — ✅ DONE
 
 ### Tasks
 
@@ -57,7 +57,7 @@ The repo lives under `terchris/devcontainer-toolbox` but needs to be under the `
   - Kept completed plans as-is (historical)
   - Kept `authors: [terchris]` in blog posts (person name)
 - [x] 1.5 Update `.gitignore` (`terchris/` → `personal/`)
-- [ ] 1.6 Commit all changes to branch (do NOT merge)
+- [x] 1.6 Commit all changes to branch (do NOT merge)
 
 ### Validation
 

--- a/website/docs/ai-development/ai-developer/plans/active/PLAN-transfer-to-helpers-no.md
+++ b/website/docs/ai-development/ai-developer/plans/active/PLAN-transfer-to-helpers-no.md
@@ -1,0 +1,141 @@
+# Plan: Transfer devcontainer-toolbox to helpers-no
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Active
+
+**Goal**: Transfer this repo from `terchris/devcontainer-toolbox` to `helpers-no/devcontainer-toolbox` with zero downtime.
+
+**Priority**: High — must be done first, other repos depend on the container image.
+
+**Last Updated**: 2026-03-18
+
+**Overall plan**: See `/Users/terje.christensen/learn/projects-2026/testing/github-helpers-no/INVESTIGATE-move-repos-to-helpers-no.md`
+
+**Report back**: After completing each phase, update the overall plan's checklist in the file above. Mark the devcontainer-toolbox line as complete when all phases are done.
+
+---
+
+## Prerequisites
+
+- None — this repo transfers first
+
+**Blocks**: All other repo transfers depend on this completing (container image at `ghcr.io/helpers-no/`)
+
+---
+
+## Problem
+
+The repo lives under `terchris/devcontainer-toolbox` but needs to be under the `helpers-no` org. There are 119 references to `terchris` across 44 files, including critical runtime references in install scripts and the container image path.
+
+---
+
+## Phase 1: Create branch and fix references — IN PROGRESS
+
+### Tasks
+
+- [x] 1.1 Create branch `move-to-helpers-no`
+- [x] 1.2 Replace `terchris/devcontainer-toolbox` → `helpers-no/devcontainer-toolbox` in critical scripts:
+  - `install.sh`
+  - `install.ps1`
+  - `.devcontainer/manage/dev-sync.sh`
+  - `.devcontainer/manage/dev-update.sh`
+  - `.devcontainer/manage/dev-template.sh`
+  - `.devcontainer/manage/lib/version-utils.sh`
+  - `.devcontainer/additions/cmd-publish-github.sh` (kept `# Author: terchris` — person name)
+  - `.devcontainer/additions/install-dev-ai-claudecode.sh`
+- [x] 1.3 Replace `ghcr.io/terchris/devcontainer-toolbox` → `ghcr.io/helpers-no/devcontainer-toolbox` in:
+  - `devcontainer-user-template.json`
+  - GH Actions workflow files (no terchris refs found — already use variables)
+- [x] 1.4 Replace `terchris` → `helpers-no` in docs/website files (~35 files)
+  - `README.md`
+  - `website/docusaurus.config.ts`
+  - `website/blog/authors.yml` (kept author name `terchris`, updated repo URL)
+  - Website docs and blog posts
+  - Kept completed plans as-is (historical)
+  - Kept `authors: [terchris]` in blog posts (person name)
+- [x] 1.5 Update `.gitignore` (`terchris/` → `personal/`)
+- [ ] 1.6 Commit all changes to branch (do NOT merge)
+
+### Validation
+
+User confirms all references are updated. Run: `grep -r "terchris" --include="*.sh" --include="*.ps1" --include="*.json" --include="*.ts" .` should return zero critical hits.
+
+---
+
+## Phase 2: Transfer repo and publish container image
+
+### Tasks
+
+- [ ] 2.1 Transfer repo on GitHub: Settings → Transfer → `helpers-no`
+- [ ] 2.2 Verify GitHub redirect works: `https://github.com/terchris/devcontainer-toolbox` → `https://github.com/helpers-no/devcontainer-toolbox`
+- [ ] 2.3 Check GH Actions workflow has permissions to publish to `ghcr.io/helpers-no/devcontainer-toolbox`
+- [ ] 2.4 Merge `move-to-helpers-no` branch
+- [ ] 2.5 Trigger container image build — verify `ghcr.io/helpers-no/devcontainer-toolbox:latest` is published
+- [ ] 2.6 Test: `docker pull ghcr.io/helpers-no/devcontainer-toolbox:latest`
+
+### Validation
+
+Container image pulls successfully from `ghcr.io/helpers-no/devcontainer-toolbox:latest`.
+
+---
+
+## Phase 3: Re-enable GitHub Pages
+
+### Tasks
+
+- [ ] 3.1 Go to repo Settings → Pages → re-enable GitHub Pages deployment
+- [ ] 3.2 Re-add custom domain: `uis.sovereignsky.no`
+- [ ] 3.3 Verify site is live at https://uis.sovereignsky.no/
+
+### Validation
+
+User confirms website loads correctly.
+
+---
+
+## Phase 4: Update local clones
+
+### Tasks
+
+- [ ] 4.1 Update local git remote: `git remote set-url origin https://github.com/helpers-no/devcontainer-toolbox.git`
+- [ ] 4.2 Notify users (<10) to update their remotes and rebuild devcontainers
+
+### Validation
+
+`git remote -v` shows `helpers-no/devcontainer-toolbox`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Repo is at `https://github.com/helpers-no/devcontainer-toolbox`
+- [ ] `ghcr.io/helpers-no/devcontainer-toolbox:latest` image is published and pullable
+- [ ] `install.sh` and `install.ps1` work from the new location
+- [ ] Website is live at `uis.sovereignsky.no`
+- [ ] No remaining `terchris` references in critical scripts
+- [ ] Old URL redirects work
+
+---
+
+## Files to Modify
+
+**Critical scripts:**
+- `install.sh`
+- `install.ps1`
+- `devcontainer-user-template.json`
+- `.devcontainer/manage/dev-sync.sh`
+- `.devcontainer/manage/dev-update.sh`
+- `.devcontainer/manage/dev-template.sh`
+- `.devcontainer/manage/lib/version-utils.sh`
+- `.devcontainer/additions/cmd-publish-github.sh`
+- `.devcontainer/additions/install-dev-ai-claudecode.sh`
+
+**Config/docs:**
+- `README.md`
+- `.gitignore`
+- `website/docusaurus.config.ts`
+- `website/blog/authors.yml`
+- ~30 website doc/blog files

--- a/website/docs/ai-development/ai-developer/plans/backlog/ISSUE-urbalurba-dev-templates-cicd.md
+++ b/website/docs/ai-development/ai-developer/plans/backlog/ISSUE-urbalurba-dev-templates-cicd.md
@@ -12,7 +12,7 @@ Add CI/CD pipeline to validate templates, auto-replace placeholders, and publish
 
 ### Problem
 
-The `dev-template` command in [devcontainer-toolbox](https://github.com/terchris/devcontainer-toolbox) copies template files as-is — it does not replace `{{GITHUB_USERNAME}}` or `{{REPO_NAME}}` placeholders. These placeholders appear in Kubernetes manifests and GitHub workflow files across all templates.
+The `dev-template` command in [devcontainer-toolbox](https://github.com/helpers-no/devcontainer-toolbox) copies template files as-is — it does not replace `{{GITHUB_USERNAME}}` or `{{REPO_NAME}}` placeholders. These placeholders appear in Kubernetes manifests and GitHub workflow files across all templates.
 
 Previously `dev-template` required a git repo to detect GitHub info and replace these, but that broke on fresh machines. The new approach is: `dev-template` just copies files, and the templates' own CI/CD handles placeholder replacement on first push.
 
@@ -78,5 +78,5 @@ jobs:
 ### Reference
 
 The devcontainer-toolbox CI/CD pipeline that creates a similar zip:
-- Workflow: [zip_dev_setup.yml](https://github.com/terchris/devcontainer-toolbox/blob/main/.github/workflows/zip_dev_setup.yml)
-- Consumer: [dev-sync.sh](https://github.com/terchris/devcontainer-toolbox/blob/main/.devcontainer/manage/dev-sync.sh) downloads the zip with `curl -fsSL`
+- Workflow: [zip_dev_setup.yml](https://github.com/helpers-no/devcontainer-toolbox/blob/main/.github/workflows/zip_dev_setup.yml)
+- Consumer: [dev-sync.sh](https://github.com/helpers-no/devcontainer-toolbox/blob/main/.devcontainer/manage/dev-sync.sh) downloads the zip with `curl -fsSL`

--- a/website/docs/ai-development/ai-developer/plans/completed/PLAN-011-prebuilt-container-image.md
+++ b/website/docs/ai-development/ai-developer/plans/completed/PLAN-011-prebuilt-container-image.md
@@ -10,7 +10,7 @@
 
 **Last Updated**: 2026-02-03
 
-**Investigation**: [INVESTIGATE-prebuilt-container-image.md](../backlog/INVESTIGATE-prebuilt-container-image.md)
+**Investigation**: [INVESTIGATE-prebuilt-container-image.md](../completed/INVESTIGATE-prebuilt-container-image.md)
 
 ---
 

--- a/website/docs/ai-development/ai-developer/plans/completed/PLAN-windows-install-image-mode.md
+++ b/website/docs/ai-development/ai-developer/plans/completed/PLAN-windows-install-image-mode.md
@@ -10,7 +10,7 @@
 
 **Last Updated**: 2026-02-03
 
-**Related**: [PLAN-011-prebuilt-container-image.md](../active/PLAN-011-prebuilt-container-image.md) (Phase 5 completed `install.sh`; this plan covers the Windows equivalent)
+**Related**: [PLAN-011-prebuilt-container-image.md](../completed/PLAN-011-prebuilt-container-image.md) (Phase 5 completed `install.sh`; this plan covers the Windows equivalent)
 
 ---
 

--- a/website/docs/ai-development/ai-docs/developing-using-ai.md
+++ b/website/docs/ai-development/ai-docs/developing-using-ai.md
@@ -169,4 +169,4 @@ Add a `CLAUDE.md` that tells the AI:
 
 - [AI Developer Docs](../ai-developer/) - Planning templates and workflow
 - [Testing Guide](../../contributors/testing) - How to run and create tests
-- [CLAUDE.md](https://github.com/terchris/devcontainer-toolbox/blob/main/CLAUDE.md) - Project-specific AI configuration (in repo root)
+- [CLAUDE.md](https://github.com/helpers-no/devcontainer-toolbox/blob/main/CLAUDE.md) - Project-specific AI configuration (in repo root)

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -37,7 +37,7 @@ Key settings:
 
 | Setting | Purpose |
 |---------|---------|
-| `image` | Pre-built image reference (`ghcr.io/terchris/devcontainer-toolbox:latest`) |
+| `image` | Pre-built image reference (`ghcr.io/helpers-no/devcontainer-toolbox:latest`) |
 | `overrideCommand` | Must be `false` so VS Code doesn't bypass the startup script |
 | `runArgs` | VPN capabilities (NET_ADMIN, NET_RAW, etc.) |
 | `customizations.vscode.extensions` | VS Code extensions to install |

--- a/website/docs/contributors/architecture/index.md
+++ b/website/docs/contributors/architecture/index.md
@@ -16,7 +16,7 @@ The toolbox has two distinct deployment modes with different `devcontainer.json`
 | **Who** | Toolbox contributors | Everyone else (user projects) |
 | **File** | `.devcontainer/devcontainer.json` | `devcontainer-user-template.json` (repo root) |
 | **How it works** | Builds from `Dockerfile.base` | Pulls pre-built image from ghcr.io |
-| **Contains** | `"build": {"dockerfile": "Dockerfile.base"}` | `"image": "ghcr.io/terchris/devcontainer-toolbox:latest"` |
+| **Contains** | `"build": {"dockerfile": "Dockerfile.base"}` | `"image": "ghcr.io/helpers-no/devcontainer-toolbox:latest"` |
 | **Requires** | Full `.devcontainer/` directory (100+ files) | Just the one JSON file |
 
 ### Single source of truth
@@ -24,7 +24,7 @@ The toolbox has two distinct deployment modes with different `devcontainer.json`
 `devcontainer-user-template.json` at the repo root is the **single source of truth** for image-mode configuration. All install scripts and deployment tools download from:
 
 ```
-https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/devcontainer-user-template.json
+https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/devcontainer-user-template.json
 ```
 
 ### Two installation paths

--- a/website/docs/contributors/index.md
+++ b/website/docs/contributors/index.md
@@ -158,8 +158,8 @@ chore: bump version to 1.2.0
 
 ## Getting Help
 
-- **Questions?** Open a [GitHub Discussion](https://github.com/terchris/devcontainer-toolbox/discussions)
-- **Found a bug?** Open an [Issue](https://github.com/terchris/devcontainer-toolbox/issues)
+- **Questions?** Open a [GitHub Discussion](https://github.com/helpers-no/devcontainer-toolbox/discussions)
+- **Found a bug?** Open an [Issue](https://github.com/helpers-no/devcontainer-toolbox/issues)
 - **Want to chat?** Comment on an existing issue or discussion
 
 ---

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -40,17 +40,17 @@ Open a terminal in your project directory and run:
 
 **Mac/Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.ps1 | iex
 ```
 
 If you see "running scripts is disabled on this system":
 ```powershell
-powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.ps1 | iex"
+powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.ps1 | iex"
 ```
 
 This creates a `.devcontainer/devcontainer.json` in your project and pulls the pre-built container image.
@@ -74,7 +74,7 @@ If your project has an older `.devcontainer/` folder with many files (Dockerfile
 
 2. Run the installer again from your project directory:
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.sh | bash
+   curl -fsSL https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.sh | bash
    ```
 
 3. Your `.devcontainer.extend/` and `.devcontainer.secrets/` are preserved — all tool selections and credentials carry over.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -15,10 +15,10 @@ Stop wasting time setting up development environments. DevContainer Toolbox give
 
 ```bash
 # Mac/Linux
-curl -fsSL https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.sh | bash
 
 # Windows PowerShell
-irm https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.ps1 | iex
 ```
 
 This creates a `.devcontainer/devcontainer.json` and pulls the pre-built image.

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -152,4 +152,4 @@ dev-help              # Show all commands
 dev-setup             # Interactive menu
 ```
 
-Still stuck? Check the [GitHub issues](https://github.com/terchris/devcontainer-toolbox/issues).
+Still stuck? Check the [GitHub issues](https://github.com/helpers-no/devcontainer-toolbox/issues).

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -8,9 +8,9 @@ const version = fs.readFileSync('../version.txt', 'utf8').trim();
 
 // Environment variables for configurable repository URLs
 // - In GitHub Actions: automatically set from repository context
-// - In local dev: uses defaults (terchris/devcontainer-toolbox)
+// - In local dev: uses defaults (helpers-no/devcontainer-toolbox)
 // - For forks: set GITHUB_ORG and GITHUB_REPO env vars or let CI auto-detect
-const GITHUB_ORG = process.env.GITHUB_ORG || 'terchris';
+const GITHUB_ORG = process.env.GITHUB_ORG || 'helpers-no';
 const GITHUB_REPO = process.env.GITHUB_REPO || 'devcontainer-toolbox';
 
 const config: Config = {

--- a/website/src/components/QuickInstall/index.tsx
+++ b/website/src/components/QuickInstall/index.tsx
@@ -14,13 +14,13 @@ export default function QuickInstall(): ReactNode {
           <div className={styles.codeBlock}>
             <p><strong>Mac/Linux</strong></p>
             <CodeBlock language="bash">
-              curl -fsSL https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.sh | bash
+              curl -fsSL https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.sh | bash
             </CodeBlock>
           </div>
           <div className={styles.codeBlock}>
             <p><strong>Windows PowerShell</strong></p>
             <CodeBlock language="powershell">
-              irm https://raw.githubusercontent.com/terchris/devcontainer-toolbox/main/install.ps1 | iex
+              irm https://raw.githubusercontent.com/helpers-no/devcontainer-toolbox/main/install.ps1 | iex
             </CodeBlock>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace all `terchris/devcontainer-toolbox` references with `helpers-no/devcontainer-toolbox`
- Update `ghcr.io` image paths, install script URLs, docs, and website
- Keep `terchris` where it refers to the person (author credits, blog author)

## Test plan
- [ ] Verify `grep -r "terchris" --include="*.sh" --include="*.ps1" --include="*.json" --include="*.ts" .` returns zero critical hits
- [ ] After merge, verify container image builds at `ghcr.io/helpers-no/devcontainer-toolbox:latest`
- [ ] Test `docker pull ghcr.io/helpers-no/devcontainer-toolbox:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)