### PR TITLE
fix: update dev-template.sh to use helpers-no/dev-templates

### DIFF
--- a/.devcontainer/manage/dev-template.sh
+++ b/.devcontainer/manage/dev-template.sh
@@ -108,7 +108,7 @@ function display_intro() {
 #------------------------------------------------------------------------------
 function download_templates() {
   local template_owner="helpers-no"
-  local template_repo="urbalurba-dev-templates"
+  local template_repo="dev-templates"
   local template_branch="main"
   local zip_url="https://github.com/$template_owner/$template_repo/archive/refs/heads/$template_branch.zip"
 

--- a/website/docs/ai-development/ai-developer/plans/backlog/ISSUE-urbalurba-dev-templates-cicd.md
+++ b/website/docs/ai-development/ai-developer/plans/backlog/ISSUE-urbalurba-dev-templates-cicd.md
@@ -1,4 +1,4 @@
-# GitHub Issue for terchris/urbalurba-dev-templates
+# GitHub Issue for helpers-no/dev-templates
 
 **Ready to post after confirmation.**
 
@@ -38,7 +38,7 @@ Create GitHub Actions workflows that:
    - Create a zip containing the `templates/` directory (and `urbalurba-scripts/` if present)
    - Publish as a GitHub release asset (e.g., `templates.zip`)
    - Use a fixed release tag (e.g., `latest`) so the download URL is stable
-   - Stable download URL: `https://github.com/terchris/urbalurba-dev-templates/releases/download/latest/templates.zip`
+   - Stable download URL: `https://github.com/helpers-no/dev-templates/releases/download/latest/templates.zip`
 
 ### Why
 

--- a/website/docs/ai-development/ai-developer/plans/backlog/PLAN-007-templates-integration.md
+++ b/website/docs/ai-development/ai-developer/plans/backlog/PLAN-007-templates-integration.md
@@ -6,7 +6,7 @@
 
 ## Status: Draft (Definition Incomplete)
 
-**Goal**: Merge project templates from urbalurba-dev-templates into DevContainer Toolbox, allowing users to start projects with pre-configured templates.
+**Goal**: Merge project templates from dev-templates into DevContainer Toolbox, allowing users to start projects with pre-configured templates.
 
 **Last Updated**: 2026-01-17
 
@@ -20,7 +20,7 @@
 
 ## Overview
 
-Currently, `dev-template.sh` downloads templates from [urbalurba-dev-templates](https://github.com/terchris/urbalurba-dev-templates). This plan merges templates into devcontainer-toolbox so the website covers both **Tools** AND **Templates/Starters**.
+Currently, `dev-template.sh` downloads templates from [dev-templates](https://github.com/helpers-no/dev-templates). This plan merges templates into devcontainer-toolbox so the website covers both **Tools** AND **Templates/Starters**.
 
 ### Website Structure After Implementation
 
@@ -41,7 +41,7 @@ DevContainer Toolbox
 
 ## Definition Tasks (To Complete Before Implementation)
 
-- [ ] Review urbalurba-dev-templates repo structure
+- [ ] Review dev-templates repo structure
 - [ ] Decide on template metadata format (TEMPLATE_* fields)
 - [ ] Decide where templates live in the repo (`templates/` folder?)
 - [ ] Decide how `dev-template.sh` will work after merge
@@ -95,7 +95,7 @@ TEMPLATE_DEMO="https://demo.example.com"  # Live demo URL (optional)
 ## Proposed Phases (Draft)
 
 ### Phase 1: Planning & Design
-- Review urbalurba-dev-templates
+- Review dev-templates
 - Finalize metadata format
 - Design website integration
 
@@ -155,5 +155,5 @@ TEMPLATE_DEMO="https://demo.example.com"  # Live demo URL (optional)
 
 ## Reference
 
-- [urbalurba-dev-templates](https://github.com/terchris/urbalurba-dev-templates)
+- [dev-templates](https://github.com/helpers-no/dev-templates)
 - INVESTIGATE-docusaurus-enhancements.md - "Future Scope: Templates Integration" section

--- a/website/docs/ai-development/ai-developer/plans/completed/PLAN-update-dev-template-repo-name.md
+++ b/website/docs/ai-development/ai-developer/plans/completed/PLAN-update-dev-template-repo-name.md
@@ -1,0 +1,71 @@
+# Plan: Update dev-template.sh after urbalurba-dev-templates rename
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Completed
+
+**Goal**: Update all references from `urbalurba-dev-templates` to `dev-templates` after the repo is renamed on GitHub.
+
+**Priority**: High
+
+**Last Updated**: 2026-03-18
+
+**Completed**: 2026-03-18
+
+**Overall plan**: See `/Users/terje.christensen/learn/projects-2026/testing/github-helpers-no/INVESTIGATE-move-repos-to-helpers-no.md`
+
+**Report back**: After completing, update the overall plan file above.
+
+---
+
+## Prerequisites
+
+- **urbalurba-dev-templates must be transferred to helpers-no AND renamed to `dev-templates`** before this plan is implemented
+- Check that `https://github.com/helpers-no/dev-templates` exists before starting
+
+---
+
+## Problem
+
+The `dev-template.sh` script and several docs/plans reference the repo as `urbalurba-dev-templates`. After the repo is renamed to `dev-templates` under `helpers-no`, these references need updating. GitHub redirects will cover the old name temporarily, but the code should use the canonical name.
+
+---
+
+## Phase 1: Update references — ✅ DONE
+
+### Tasks
+
+- [x] 1.1 Update `dev-template.sh` runtime reference:
+  - `.devcontainer/manage/dev-template.sh` line 111: `local template_repo="urbalurba-dev-templates"` → `local template_repo="dev-templates"`
+- [x] 1.2 Search for any other runtime references — zero other runtime hits
+- [x] 1.3 Update docs/plan references:
+  - `ISSUE-urbalurba-dev-templates-cicd.md` — updated title and download URL
+  - `PLAN-007-templates-integration.md` — updated all references
+  - Completed plans left as-is (historical)
+- [x] 1.4 Commit changes
+
+### Validation
+
+`grep -r "urbalurba-dev-templates" --include="*.sh" --include="*.ps1" --include="*.json" --include="*.ts" .` returns zero hits.
+
+---
+
+## Acceptance Criteria
+
+- [x] `dev-template.sh` uses `dev-templates` as the repo name
+- [ ] Template download works: `dev-template` command successfully fetches from `helpers-no/dev-templates` (needs testing in devcontainer)
+- [x] No remaining `urbalurba-dev-templates` in runtime scripts
+
+---
+
+## Files to Modify
+
+**Critical:**
+- `.devcontainer/manage/dev-template.sh`
+
+**Docs (update for correctness):**
+- `website/docs/ai-development/ai-developer/plans/backlog/ISSUE-urbalurba-dev-templates-cicd.md`
+- `website/docs/ai-development/ai-developer/plans/backlog/PLAN-007-templates-integration.md`
+- Completed plan/investigation files that reference the old name


### PR DESCRIPTION
## Summary
- Update `dev-template.sh` runtime reference from `urbalurba-dev-templates` to `dev-templates`
- Update backlog docs (ISSUE and PLAN-007) with new repo name and URL
- Complete and archive the plan

## Test plan
- [ ] Verify `grep -r "urbalurba-dev-templates" --include="*.sh" .` returns zero hits
- [ ] Test `dev-template` command in devcontainer fetches from `helpers-no/dev-templates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)