### PR TITLE
feat: TEMPLATE_README, PURPOSE→ABSTRACT rename, bug fixes

### DIFF
--- a/.devcontainer/manage/dev-template-ai.sh
+++ b/.devcontainer/manage/dev-template-ai.sh
@@ -81,8 +81,9 @@ function scan_templates() {
   TEMPLATE_NAMES=()
   TEMPLATE_DESCRIPTIONS=()
   TEMPLATE_CATEGORIES=()
-  TEMPLATE_PURPOSES=()
+  TEMPLATE_ABSTRACTS=()
   TEMPLATE_TOOLS_LIST=()
+  TEMPLATE_README_LIST=()
 
   # Group by category — AI templates use WORKFLOW category
   declare -g -A CATEGORY_WORKFLOW
@@ -98,8 +99,9 @@ function scan_templates() {
       TEMPLATE_NAMES+=("$INFO_NAME")
       TEMPLATE_DESCRIPTIONS+=("$INFO_DESCRIPTION")
       TEMPLATE_CATEGORIES+=("$INFO_CATEGORY")
-      TEMPLATE_PURPOSES+=("$INFO_PURPOSE")
+      TEMPLATE_ABSTRACTS+=("$INFO_ABSTRACT")
       TEMPLATE_TOOLS_LIST+=("$INFO_TOOLS")
+      TEMPLATE_README_LIST+=("$INFO_README")
 
       case "$INFO_CATEGORY" in
         WORKFLOW)
@@ -179,6 +181,12 @@ function select_template() {
 
     if [ ! -d "$TEMPLATE_REPO_DIR/$TEMPLATES_SUBDIR/$SELECTED_TEMPLATE" ]; then
       echo "❌ AI template '$SELECTED_TEMPLATE' not found"
+      echo ""
+      echo "   Available templates:"
+      for i in "${!TEMPLATE_DIRS[@]}"; do
+        echo "   - ${TEMPLATE_DIRS[$i]}  (${TEMPLATE_NAMES[$i]})"
+      done
+      echo ""
       rm -rf "$TEMP_DIR"
       exit 2
     fi
@@ -206,10 +214,10 @@ function select_template() {
   display_intro
   echo "✅ Selected: ${TEMPLATE_NAMES[$TEMPLATE_INDEX]}"
 
-  if [ -n "${TEMPLATE_PURPOSES[$TEMPLATE_INDEX]}" ]; then
+  if [ -n "${TEMPLATE_ABSTRACTS[$TEMPLATE_INDEX]}" ]; then
     echo ""
     echo "📝 About this template:"
-    echo "   ${TEMPLATE_PURPOSES[$TEMPLATE_INDEX]}"
+    echo "   ${TEMPLATE_ABSTRACTS[$TEMPLATE_INDEX]}"
   fi
   echo ""
 
@@ -362,9 +370,31 @@ function cleanup_and_complete() {
   fi
   echo ""
   echo "📝 Next steps:"
-  echo "   1. Review docs/ai-developer/README.md for the complete guide"
-  echo "   2. Review CLAUDE.md and customize for your project"
-  echo "   3. Start your first task: tell your AI assistant what you want to build"
+  echo ""
+
+  local step=1
+  local tools="${TEMPLATE_TOOLS_LIST[$TEMPLATE_INDEX]:-}"
+  local readme="${TEMPLATE_README_LIST[$TEMPLATE_INDEX]:-}"
+
+  if [ -n "$tools" ]; then
+    echo "   $step. Update your terminal (tools were installed):"
+    echo "      source ~/.bashrc"
+    echo ""
+    ((step++))
+  fi
+
+  if [ -n "$readme" ]; then
+    echo "   $step. Read the template instructions:"
+    echo "      cat $readme"
+    echo ""
+    ((step++))
+  else
+    echo "   $step. Review docs/ai-developer/README.md for the complete guide"
+    echo ""
+    ((step++))
+  fi
+
+  echo "   $step. Start your first task: tell your AI assistant what you want to build"
   echo ""
 }
 

--- a/.devcontainer/manage/dev-template.sh
+++ b/.devcontainer/manage/dev-template.sh
@@ -112,8 +112,9 @@ function scan_templates() {
   TEMPLATE_NAMES=()
   TEMPLATE_DESCRIPTIONS=()
   TEMPLATE_CATEGORIES=()
-  TEMPLATE_PURPOSES=()
+  TEMPLATE_ABSTRACTS=()
   TEMPLATE_TOOLS_LIST=()
+  TEMPLATE_README_LIST=()
 
   # Group by category
   declare -g -A CATEGORY_WEB_SERVER
@@ -130,8 +131,9 @@ function scan_templates() {
       TEMPLATE_NAMES+=("$INFO_NAME")
       TEMPLATE_DESCRIPTIONS+=("$INFO_DESCRIPTION")
       TEMPLATE_CATEGORIES+=("$INFO_CATEGORY")
-      TEMPLATE_PURPOSES+=("$INFO_PURPOSE")
+      TEMPLATE_ABSTRACTS+=("$INFO_ABSTRACT")
       TEMPLATE_TOOLS_LIST+=("$INFO_TOOLS")
+      TEMPLATE_README_LIST+=("$INFO_README")
 
       # Group by category for menu display
       case "$INFO_CATEGORY" in
@@ -226,17 +228,23 @@ function select_template() {
   
   if [ -n "$param_name" ]; then
     # Direct selection by directory name
-    TEMPLATE_NAME="$param_name"
-    
-    if [ ! -d "$TEMPLATE_REPO_DIR/templates/$TEMPLATE_NAME" ]; then
-      echo "❌ Template '$TEMPLATE_NAME' not found"
+    SELECTED_TEMPLATE="$param_name"
+
+    if [ ! -d "$TEMPLATE_REPO_DIR/templates/$SELECTED_TEMPLATE" ]; then
+      echo "❌ Template '$SELECTED_TEMPLATE' not found"
+      echo ""
+      echo "   Available templates:"
+      for i in "${!TEMPLATE_DIRS[@]}"; do
+        echo "   - ${TEMPLATE_DIRS[$i]}  (${TEMPLATE_NAMES[$i]})"
+      done
+      echo ""
       rm -rf "$TEMP_DIR"
       exit 2
     fi
-    
+
     # Find index for display
     for i in "${!TEMPLATE_DIRS[@]}"; do
-      if [ "${TEMPLATE_DIRS[$i]}" == "$TEMPLATE_NAME" ]; then
+      if [ "${TEMPLATE_DIRS[$i]}" == "$SELECTED_TEMPLATE" ]; then
         TEMPLATE_INDEX=$i
         break
       fi
@@ -247,28 +255,28 @@ function select_template() {
       local choice
       choice=$(show_template_menu)
       TEMPLATE_INDEX=${MENU_TO_INDEX[$choice]}
-      
+
       # Show details and get confirmation
       if show_template_details $TEMPLATE_INDEX; then
-        TEMPLATE_NAME="${TEMPLATE_DIRS[$TEMPLATE_INDEX]}"
+        SELECTED_TEMPLATE="${TEMPLATE_DIRS[$TEMPLATE_INDEX]}"
         break
       fi
       # If user said no, loop back to menu
     done
   fi
-  
+
   clear
   display_intro
   echo "✅ Selected: ${TEMPLATE_NAMES[$TEMPLATE_INDEX]}"
-  
-  if [ -n "${TEMPLATE_PURPOSES[$TEMPLATE_INDEX]}" ]; then
+
+  if [ -n "${TEMPLATE_ABSTRACTS[$TEMPLATE_INDEX]}" ]; then
     echo ""
     echo "📝 About this template:"
-    echo "   ${TEMPLATE_PURPOSES[$TEMPLATE_INDEX]}"
+    echo "   ${TEMPLATE_ABSTRACTS[$TEMPLATE_INDEX]}"
   fi
   echo ""
   
-  TEMPLATE_PATH="$TEMPLATE_REPO_DIR/templates/$TEMPLATE_NAME"
+  TEMPLATE_PATH="$TEMPLATE_REPO_DIR/templates/$SELECTED_TEMPLATE"
 }
 
 #------------------------------------------------------------------------------
@@ -326,7 +334,7 @@ function merge_gitignore() {
       TEMP_MERGED=$(mktemp)
       cat "$CALLER_DIR/.gitignore" > "$TEMP_MERGED"
       echo "" >> "$TEMP_MERGED"
-      echo "# Added from template $TEMPLATE_NAME" >> "$TEMP_MERGED"
+      echo "# Added from template $SELECTED_TEMPLATE" >> "$TEMP_MERGED"
       
       while IFS= read -r line; do
         if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
@@ -401,9 +409,27 @@ function cleanup_and_complete() {
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
   echo "📝 Next steps:"
-  echo "   1. Review the files that were created"
-  echo "   2. Run any setup commands in the template's README"
-  echo "   3. Commit and push your project to GitHub"
+  echo ""
+
+  local step=1
+  local tools="${TEMPLATE_TOOLS_LIST[$TEMPLATE_INDEX]:-}"
+  local readme="${TEMPLATE_README_LIST[$TEMPLATE_INDEX]:-}"
+
+  if [ -n "$tools" ]; then
+    echo "   $step. Update your terminal (tools were installed):"
+    echo "      source ~/.bashrc"
+    echo ""
+    ((step++))
+  fi
+
+  if [ -n "$readme" ]; then
+    echo "   $step. Read the template instructions:"
+    echo "      cat $readme"
+    echo ""
+    ((step++))
+  fi
+
+  echo "   $step. Commit and push your project to GitHub"
   echo ""
 }
 
@@ -449,7 +475,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 fi
 
 # Get template name from command line (optional)
-TEMPLATE_NAME="${1:-}"
+SELECTED_TEMPLATE_ARG="${1:-}"
 
 # Check prerequisites
 check_prerequisites
@@ -464,7 +490,7 @@ display_intro
 # Run the process
 download_templates
 scan_templates
-select_template "$TEMPLATE_NAME"
+select_template "$SELECTED_TEMPLATE_ARG"
 verify_template
 copy_template_files
 setup_github_workflows

--- a/.devcontainer/manage/lib/template-common.sh
+++ b/.devcontainer/manage/lib/template-common.sh
@@ -94,7 +94,7 @@ download_template_repo() {
 #   $1 — path to template directory containing TEMPLATE_INFO
 #
 # Sets globals:
-#   INFO_NAME, INFO_DESCRIPTION, INFO_CATEGORY, INFO_PURPOSE, INFO_TOOLS
+#   INFO_NAME, INFO_DESCRIPTION, INFO_CATEGORY, INFO_ABSTRACT, INFO_TOOLS, INFO_README
 #------------------------------------------------------------------------------
 read_template_info() {
   local template_dir="$1"
@@ -104,23 +104,25 @@ read_template_info() {
   INFO_NAME=$(basename "$template_dir")
   INFO_DESCRIPTION="No description"
   INFO_CATEGORY="UNCATEGORIZED"
-  INFO_PURPOSE=""
+  INFO_ABSTRACT=""
   INFO_TOOLS=""
+  INFO_README=""
 
   if [ -f "$info_file" ]; then
     # Unset variables to avoid pollution (prevents leaking between templates)
-    unset TEMPLATE_NAME TEMPLATE_DESCRIPTION TEMPLATE_CATEGORY TEMPLATE_PURPOSE TEMPLATE_TOOLS
+    unset TEMPLATE_NAME TEMPLATE_DESCRIPTION TEMPLATE_CATEGORY TEMPLATE_ABSTRACT TEMPLATE_TOOLS TEMPLATE_README
 
     source "$info_file"
 
     INFO_NAME="${TEMPLATE_NAME:-$INFO_NAME}"
     INFO_DESCRIPTION="${TEMPLATE_DESCRIPTION:-$INFO_DESCRIPTION}"
     INFO_CATEGORY="${TEMPLATE_CATEGORY:-$INFO_CATEGORY}"
-    INFO_PURPOSE="${TEMPLATE_PURPOSE:-$INFO_PURPOSE}"
+    INFO_ABSTRACT="${TEMPLATE_ABSTRACT:-$INFO_ABSTRACT}"
     INFO_TOOLS="${TEMPLATE_TOOLS:-$INFO_TOOLS}"
+    INFO_README="${TEMPLATE_README:-$INFO_README}"
 
     # Clean up after sourcing
-    unset TEMPLATE_NAME TEMPLATE_DESCRIPTION TEMPLATE_CATEGORY TEMPLATE_PURPOSE TEMPLATE_TOOLS
+    unset TEMPLATE_NAME TEMPLATE_DESCRIPTION TEMPLATE_CATEGORY TEMPLATE_ABSTRACT TEMPLATE_TOOLS TEMPLATE_README
   fi
 }
 
@@ -132,7 +134,7 @@ read_template_info() {
 #
 # Requires globals:
 #   TEMPLATE_NAMES[], TEMPLATE_DESCRIPTIONS[], TEMPLATE_CATEGORIES[],
-#   TEMPLATE_PURPOSES[], TEMPLATE_DIRS[], TEMPLATE_TOOLS_LIST[] (optional)
+#   TEMPLATE_ABSTRACTS[], TEMPLATE_DIRS[], TEMPLATE_TOOLS_LIST[] (optional)
 #
 # Returns: dialog exit code (0 = yes, 1 = no)
 #------------------------------------------------------------------------------
@@ -141,15 +143,15 @@ show_template_details_dialog() {
   local template_name="${TEMPLATE_NAMES[$idx]}"
   local template_desc="${TEMPLATE_DESCRIPTIONS[$idx]}"
   local template_category="${TEMPLATE_CATEGORIES[$idx]}"
-  local template_purpose="${TEMPLATE_PURPOSES[$idx]}"
+  local template_abstract="${TEMPLATE_ABSTRACTS[$idx]:-}"
 
   local details=""
   details+="Name: $template_name\n\n"
   details+="Category: $template_category\n\n"
   details+="Description:\n$template_desc\n\n"
 
-  if [ -n "$template_purpose" ]; then
-    details+="Purpose:\n$template_purpose\n\n"
+  if [ -n "$template_abstract" ]; then
+    details+="About:\n$template_abstract\n\n"
   fi
 
   local template_tools="${TEMPLATE_TOOLS_LIST[$idx]:-}"
@@ -200,16 +202,16 @@ install_template_tools() {
 
     if [ ! -f "$script_path" ]; then
       echo "   ⚠️  Tool '$tool_id' not found ($script)"
-      ((skipped++))
+      skipped=$((skipped + 1))
       continue
     fi
 
     echo "   📦 Installing $tool_id..."
     if bash "$script_path"; then
-      ((installed++))
+      installed=$((installed + 1))
     else
       echo "   ⚠️  Failed to install $tool_id — you can install it later with dev-setup"
-      ((failed++))
+      failed=$((failed + 1))
     fi
     echo ""
   done

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -129,6 +129,7 @@ RUN sudo ln -sf /opt/devcontainer-toolbox/manage/dev-setup.sh /usr/local/bin/dev
     sudo ln -sf /opt/devcontainer-toolbox/manage/dev-log.sh /usr/local/bin/dev-log && \
     sudo ln -sf /opt/devcontainer-toolbox/manage/dev-tools.sh /usr/local/bin/dev-tools && \
     sudo ln -sf /opt/devcontainer-toolbox/manage/dev-sync.sh /usr/local/bin/dev-sync && \
+    sudo ln -sf /opt/devcontainer-toolbox/manage/dev-template-ai.sh /usr/local/bin/dev-template-ai && \
     # Make all scripts executable (files owned by vscode via --chown)
     chmod +x /opt/devcontainer-toolbox/manage/*.sh && \
     chmod +x /opt/devcontainer-toolbox/additions/*.sh 2>/dev/null || true && \

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-advanced-templates.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-advanced-templates.md
@@ -250,11 +250,13 @@ TEMPLATE_SERVICES="postgresql"              # backend services (future)
 
 ## Questions to Answer
 
-### Tool dependencies (ready to implement)
+### Tool dependencies -- COMPLETED 2026-03-30
 
-1. Should `TEMPLATE_TOOLS` be added to `TEMPLATE_INFO` format? (proposed above)
-2. Should tools install automatically or ask the user first?
-3. What if a tool install fails — abort template install or continue with warning?
+1. ~~Should `TEMPLATE_TOOLS` be added to `TEMPLATE_INFO` format?~~ **Yes -- implemented.**
+2. ~~Should tools install automatically or ask the user first?~~ **Automatically, shown in dialog before confirmation.**
+3. ~~What if a tool install fails?~~ **Warn and continue, don't abort.**
+
+See `PLAN-template-tools-dct.md` (completed) and `PLAN-template-tools-dev-templates.md` (completed in helpers-no/dev-templates).
 
 ### Backend service dependencies (future)
 
@@ -276,13 +278,13 @@ The `.env.example` pattern should be the foundation regardless of which option w
 
 ## Next Steps
 
-### Immediate (TEMPLATE_TOOLS)
+### Immediate (TEMPLATE_TOOLS) -- COMPLETED 2026-03-30
 
-- [ ] Add `TEMPLATE_TOOLS` field to TEMPLATE_INFO format spec (in dev-templates repo)
-- [ ] Add `install_template_tools()` to `template-common.sh`
-- [ ] Update `dev-template.sh` and `dev-template-ai.sh` to read and process `TEMPLATE_TOOLS`
-- [ ] Update PHP template TEMPLATE_INFO with `TEMPLATE_TOOLS="dev-php-laravel"`
-- [ ] Create PLAN for implementing TEMPLATE_TOOLS
+- [x] Add `TEMPLATE_TOOLS` field to TEMPLATE_INFO format spec (in dev-templates repo)
+- [x] Add `install_template_tools()` to `template-common.sh`
+- [x] Update `dev-template.sh` and `dev-template-ai.sh` to read and process `TEMPLATE_TOOLS`
+- [x] Update all 7 app templates with `TEMPLATE_TOOLS` (in dev-templates repo)
+- [x] Create and complete PLAN for implementing TEMPLATE_TOOLS
 
 ### Future (backend services)
 

--- a/website/docs/ai-developer/plans/backlog/INVESTIGATE-php-install-scripts.md
+++ b/website/docs/ai-developer/plans/backlog/INVESTIGATE-php-install-scripts.md
@@ -1,0 +1,130 @@
+# Investigate: PHP Install Scripts — Split and Fix Instructions
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Backlog
+
+**Goal**: Fix two problems with PHP tool installation: (1) no simple PHP-only install script exists, and (2) the Laravel install script gives instructions that don't work.
+
+**Priority**: High
+
+**Last Updated**: 2026-03-30
+
+---
+
+## Problem 1: No simple PHP install script
+
+The only PHP install script is `install-dev-php-laravel.sh` which bundles PHP + Composer + Laravel Installer. When a user installs the "PHP Basic Webserver" template (which uses plain PHP with the built-in server), they get Laravel tools they don't need.
+
+PHP developers don't always use Laravel. Common PHP use cases:
+- Plain PHP with built-in server (like the basic webserver template)
+- Symfony framework
+- Slim micro framework (APIs)
+- WordPress / Drupal CMS
+- Composer-based projects without a framework
+
+**What's needed:** A simple `install-dev-php.sh` that installs PHP + Composer only. Laravel should be a separate, additional script.
+
+### Current state
+
+```
+install-dev-php-laravel.sh
+  SCRIPT_ID="dev-php-laravel"
+  Installs: PHP 8.4, Composer, Laravel Installer
+  VS Code extensions: 7 (including Laravel-specific ones)
+  Post-install message: assumes Laravel project
+```
+
+### Proposed split
+
+```
+install-dev-php.sh              (NEW)
+  SCRIPT_ID="dev-php"
+  Installs: PHP, Composer
+  VS Code extensions: PHP Intelephense, PHP Debug, PHP DocBlocker, Composer
+  Post-install message: generic PHP instructions
+
+install-dev-php-laravel.sh      (MODIFIED)
+  SCRIPT_ID="dev-php-laravel"
+  SCRIPT_PREREQUISITES="install-dev-php.sh" (or depends on dev-php)
+  Installs: Laravel Installer (on top of dev-php)
+  VS Code extensions: Laravel Blade Snippets, Laravel Artisan, PHP Namespace Resolver
+  Post-install message: Laravel-specific instructions
+```
+
+### Impact on templates
+
+The PHP Basic Webserver template in dev-templates would change:
+```bash
+# Before
+TEMPLATE_TOOLS="dev-php-laravel"
+
+# After
+TEMPLATE_TOOLS="dev-php"
+```
+
+---
+
+## Problem 2: Laravel install script instructions don't work
+
+After installing the PHP Basic Webserver template, the `install-dev-php-laravel.sh` post-install message says:
+
+```
+Next steps:
+  1. Run: source ~/.bashrc
+  2. Then: composer run dev
+  3. Open: http://localhost:8000
+```
+
+But `composer run dev` fails because there is no `composer.json` in the workspace — the template is a plain PHP app, not a Laravel project:
+
+```
+$ composer run dev
+Composer could not find a composer.json file in /workspace
+```
+
+Even for a Laravel project, these instructions are wrong — you'd need to create a project first with `laravel new my-project` before `composer run dev` works.
+
+### Root cause
+
+The `post_installation_message()` in `install-dev-php-laravel.sh` assumes:
+1. The user is building a Laravel project
+2. A Laravel project already exists in the workspace
+3. `composer.json` is present
+
+None of these are true right after installing tools.
+
+### Fix options
+
+**Option A:** Make `post_installation_message()` conditional — detect if `composer.json` exists and show different messages.
+
+**Option B:** Make the message generic — "Tools installed. See your project's README for how to run it."
+
+**Option C:** Split into two scripts (Problem 1 fix) — the generic `install-dev-php.sh` shows generic PHP instructions, and `install-dev-php-laravel.sh` shows Laravel-specific instructions that start with "Create a new project first."
+
+---
+
+## Questions to Answer
+
+1. Should `install-dev-php.sh` use the same installation method (php.new/Herd Lite) or install via apt?
+2. Should `install-dev-php-laravel.sh` depend on `install-dev-php.sh` via SCRIPT_PREREQUISITES, or bundle everything?
+3. Which VS Code extensions belong in the base PHP script vs the Laravel script?
+4. Should post-install messages ever assume a project structure, or always be generic?
+
+---
+
+## Recommendation
+
+*To be determined after investigation.*
+
+---
+
+## Next Steps
+
+- [ ] Analyse `install-dev-php-laravel.sh` to understand the installation method
+- [ ] Determine how to split PHP from Laravel cleanly
+- [ ] Fix post-install message for both scripts
+- [ ] Update TEMPLATE_TOOLS in dev-templates PHP template (from `dev-php-laravel` to `dev-php`)
+- [ ] Create PLAN with implementation tasks

--- a/website/docs/ai-developer/plans/completed/PLAN-template-readme-instructions.md
+++ b/website/docs/ai-developer/plans/completed/PLAN-template-readme-instructions.md
@@ -1,0 +1,117 @@
+# Feature: Show template README instructions after install
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Completed
+
+**Completed**: 2026-04-01
+
+**Goal**: After template install, tell the user exactly how to read the template's README with a copy-paste command.
+
+**Last Updated**: 2026-03-30
+
+---
+
+## Problem
+
+After installing a template, the user sees tool-specific post-install messages (e.g., PHP installer says `composer run dev` which doesn't work for a basic PHP template). The template's README has the correct instructions, but the user isn't told to read it.
+
+Additionally, when tools are installed, the user needs to run `source ~/.bashrc` to update their PATH — but this is buried in the tool output.
+
+## Important: completion message must be the last output
+
+Tool install scripts (e.g., PHP) print their own verbose `post_installation_message()` during install — including potentially wrong instructions like `composer run dev`. This output can be very long (tool download, extensions, etc.). The template installer's `✅ Template setup complete!` message with the correct next steps MUST be the final thing the user sees, so it's not lost in the scroll. The current code already puts `cleanup_and_complete()` last in the flow, which is correct. The key is that the completion message overrides/replaces any confusing tool-specific instructions with the template-specific ones.
+
+## Solution
+
+Add `TEMPLATE_README` field to `TEMPLATE_INFO`. The template installer shows clear copy-paste instructions at the end:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ Template setup complete!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+📝 Next steps:
+
+   1. Update your terminal (tools were installed):
+      source ~/.bashrc
+
+   2. Read the template instructions:
+      cat README-php-basic-webserver.md
+```
+
+Step 1 only shown if tools were installed. Step 2 only shown if `TEMPLATE_README` is set.
+
+---
+
+## Phase 1: Add TEMPLATE_README to shared library (DCT side) -- DONE
+
+### Tasks
+
+- [x] 1.1 Update `read_template_info()` in `template-common.sh`:
+  - Add `INFO_README=""` default
+  - Add `TEMPLATE_README` to unset before/after sourcing
+  - Read `INFO_README="${TEMPLATE_README:-$INFO_README}"`
+  - Rename `TEMPLATE_PURPOSE` → `TEMPLATE_ABSTRACT`: change `INFO_PURPOSE` to `INFO_ABSTRACT`, read from `TEMPLATE_ABSTRACT` instead of `TEMPLATE_PURPOSE` (dev-templates repo is renaming this field simultaneously — no backward compatibility needed)
+- [x] 1.2 Add `TEMPLATE_README_LIST=()` array to `scan_templates()` in both scripts
+- [x] 1.3 Update `cleanup_and_complete()` in `dev-template.sh`:
+  - If tools were installed, show: `source ~/.bashrc`
+  - If `TEMPLATE_README_LIST[$TEMPLATE_INDEX]` is set, show: `cat {readme-filename}`
+- [x] 1.4 Update `cleanup_and_complete()` in `dev-template-ai.sh` — same pattern
+
+### Validation
+
+Completion message shows correct copy-paste commands.
+
+---
+
+## Phase 2: Add TEMPLATE_README to templates (dev-templates side) -- DONE
+
+### Tasks
+
+- [x] 2.1 Add `TEMPLATE_README="README-php-basic-webserver.md"` to PHP template
+- [x] 2.2 Add `TEMPLATE_README` to all other app templates
+- [x] 2.3 AI templates: add `TEMPLATE_README` if applicable
+
+### Validation
+
+Each template's TEMPLATE_INFO has the correct README filename.
+
+---
+
+## Phase 3: Testing -- DONE
+
+### Tasks
+
+- [x] 3.1 Test PHP template — completion message shows `cat README-php-basic-webserver.md`
+- [x] 3.2 Test AI template — no README instruction if not set (backward compatible)
+- [x] 3.3 Test template with tools — `source ~/.bashrc` instruction shown
+- [x] 3.4 Test template without tools — no `source ~/.bashrc` instruction
+
+### Validation
+
+All tests pass.
+
+---
+
+## Acceptance Criteria
+
+- [x] `TEMPLATE_README` field read from `TEMPLATE_INFO`
+- [x] Completion message shows `source ~/.bashrc` when tools were installed
+- [x] Completion message shows `cat {readme}` when `TEMPLATE_README` is set
+- [x] Backward compatible — templates without `TEMPLATE_README` work as before
+- [x] Works in both `dev-template.sh` and `dev-template-ai.sh`
+
+---
+
+## Files to Modify
+
+**DCT side:**
+- `.devcontainer/manage/lib/template-common.sh` — read `TEMPLATE_README`
+- `.devcontainer/manage/dev-template.sh` — show README in completion, add `TEMPLATE_README_LIST`
+- `.devcontainer/manage/dev-template-ai.sh` — same
+
+**dev-templates side (companion):**
+- All `TEMPLATE_INFO` files — add `TEMPLATE_README` field

--- a/website/docs/ai-developer/plans/completed/PLAN-template-tools-dct.md
+++ b/website/docs/ai-developer/plans/completed/PLAN-template-tools-dct.md
@@ -4,7 +4,9 @@
 > - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
 > - [PLANS.md](../../PLANS.md) - Plan structure and best practices
 
-## Status: Active
+## Status: Completed
+
+**Completed**: 2026-03-30
 
 **Goal**: Make `dev-template.sh` and `dev-template-ai.sh` read `TEMPLATE_TOOLS` from `TEMPLATE_INFO` and automatically install the required devcontainer tools.
 
@@ -36,16 +38,16 @@ When a user installs a template (e.g., PHP Basic Webserver), the required runtim
 
 ---
 
-## Phase 1: Update shared library
+## Phase 1: Update shared library -- DONE
 
 ### Tasks
 
-- [ ] 1.1 Update `read_template_info()` in `lib/template-common.sh`:
+- [x] 1.1 Update `read_template_info()` in `lib/template-common.sh`:
   - Add `INFO_TOOLS=""` default
   - Add `TEMPLATE_TOOLS` to the `unset` line BEFORE sourcing (prevents leaking between templates)
   - Read `INFO_TOOLS="${TEMPLATE_TOOLS:-$INFO_TOOLS}"`
   - Add `TEMPLATE_TOOLS` to the `unset` line AFTER sourcing (cleanup)
-- [ ] 1.2 Add `install_template_tools()` function to `lib/template-common.sh`:
+- [x] 1.2 Add `install_template_tools()` function to `lib/template-common.sh`:
   - Takes space-separated SCRIPT_IDs as argument
   - For each ID, find `install-${ID}.sh` in `$ADDITIONS_DIR`
   - If script exists, run it with `bash "$script_path"`
@@ -63,15 +65,15 @@ Library function exists, handles single tool, multiple tools, empty tools, and u
 
 ---
 
-## Phase 2: Integrate into dev-template.sh
+## Phase 2: Integrate into dev-template.sh -- DONE
 
 ### Tasks
 
-- [ ] 2.1 Add `TEMPLATE_TOOLS_LIST=()` array to `scan_templates()`
-- [ ] 2.2 Add `TEMPLATE_TOOLS_LIST+=("$INFO_TOOLS")` in the scan loop
-- [ ] 2.3 Show tools in `show_template_details()` dialog -- add "Tools: dev-php-laravel" to the details text if `TEMPLATE_TOOLS_LIST[$idx]` is non-empty
-- [ ] 2.4 Call `install_template_tools "${TEMPLATE_TOOLS_LIST[$TEMPLATE_INDEX]}"` in main flow AFTER `copy_template_files` and BEFORE `process_template_files`
-- [ ] 2.5 Update `--help` text to mention that required tools are installed automatically
+- [x] 2.1 Add `TEMPLATE_TOOLS_LIST=()` array to `scan_templates()`
+- [x] 2.2 Add `TEMPLATE_TOOLS_LIST+=("$INFO_TOOLS")` in the scan loop
+- [x] 2.3 Show tools in `show_template_details()` dialog -- add "Tools: dev-php-laravel" to the details text if `TEMPLATE_TOOLS_LIST[$idx]` is non-empty
+- [x] 2.4 Call `install_template_tools "${TEMPLATE_TOOLS_LIST[$TEMPLATE_INDEX]}"` in main flow AFTER `copy_template_files` and BEFORE `process_template_files`
+- [x] 2.5 Update `--help` text to mention that required tools are installed automatically
 
 ### Validation
 
@@ -79,15 +81,15 @@ Running `dev-template` with PHP template shows tools in details dialog and insta
 
 ---
 
-## Phase 3: Integrate into dev-template-ai.sh
+## Phase 3: Integrate into dev-template-ai.sh -- DONE
 
 ### Tasks
 
-- [ ] 3.1 Add `TEMPLATE_TOOLS_LIST=()` array to `scan_templates()`
-- [ ] 3.2 Add `TEMPLATE_TOOLS_LIST+=("$INFO_TOOLS")` in the scan loop
-- [ ] 3.3 Show tools in `show_template_details_dialog()` if non-empty (via the shared function or locally)
-- [ ] 3.4 Call `install_template_tools "${TEMPLATE_TOOLS_LIST[$TEMPLATE_INDEX]}"` in main flow AFTER `copy_template_files` and BEFORE `process_template_files`
-- [ ] 3.5 Update `--help` text to mention that required tools are installed automatically
+- [x] 3.1 Add `TEMPLATE_TOOLS_LIST=()` array to `scan_templates()`
+- [x] 3.2 Add `TEMPLATE_TOOLS_LIST+=("$INFO_TOOLS")` in the scan loop
+- [x] 3.3 Show tools in `show_template_details_dialog()` if non-empty (via the shared function or locally)
+- [x] 3.4 Call `install_template_tools "${TEMPLATE_TOOLS_LIST[$TEMPLATE_INDEX]}"` in main flow AFTER `copy_template_files` and BEFORE `process_template_files`
+- [x] 3.5 Update `--help` text to mention that required tools are installed automatically
 
 ### Validation
 
@@ -95,31 +97,31 @@ Running `dev-template` with PHP template shows tools in details dialog and insta
 
 ---
 
-## Phase 4: Testing
+## Phase 4: Testing -- DONE
 
 ### Tasks
 
 **Happy path:**
-- [ ] 4.1 Test `dev-template` with PHP template -- PHP should auto-install, show in dialog details
-- [ ] 4.2 Test `dev-template-ai` with plan-based-workflow -- no tools, should work as before (backward compatible)
-- [ ] 4.3 Verify template details dialog shows "Tools to install: dev-php-laravel" before confirmation
-- [ ] 4.4 Verify tools persist in `enabled-tools.conf` after install
-- [ ] 4.5 Verify `--help` text mentions automatic tool installation
+- [x] 4.1 Test `dev-template` with PHP template -- PHP should auto-install, show in dialog details
+- [x] 4.2 Test `dev-template-ai` with plan-based-workflow -- no tools, should work as before (backward compatible)
+- [x] 4.3 Verify template details dialog shows "Tools to install: dev-php-laravel" before confirmation
+- [x] 4.4 Verify tools persist in `enabled-tools.conf` after install
+- [x] 4.5 Verify `--help` text mentions automatic tool installation
 
 **Idempotency:**
-- [ ] 4.6 Re-run `dev-template` on same project -- tools should skip (already installed)
+- [x] 4.6 Re-run `dev-template` on same project -- tools should skip (already installed)
 
 **Error handling:**
-- [ ] 4.7 Test with unknown tool ID -- should warn and continue, not abort template install
-- [ ] 4.8 Test with a tool that fails to install -- should warn and continue, remaining tools still install, template files still in place, completion message still shows
-- [ ] 4.9 Verify cleanup runs even if tool install fails (temp dir removed)
+- [x] 4.7 Test with unknown tool ID -- should warn and continue, not abort template install
+- [x] 4.8 Test with a tool that fails to install -- should warn and continue, remaining tools still install, template files still in place, completion message still shows
+- [x] 4.9 Verify cleanup runs even if tool install fails (temp dir removed)
 
 **Multiple tools:**
-- [ ] 4.10 Test with template that has multiple tools (edit a TEMPLATE_INFO temporarily to have two tools) -- both should install
+- [x] 4.10 Test with template that has multiple tools (edit a TEMPLATE_INFO temporarily to have two tools) -- both should install
 
 **Regression:**
-- [ ] 4.11 Verify `dev-template.sh` still works end-to-end after changes
-- [ ] 4.12 Verify `dev-template-ai.sh` still works end-to-end after changes
+- [x] 4.11 Verify `dev-template.sh` still works end-to-end after changes
+- [x] 4.12 Verify `dev-template-ai.sh` still works end-to-end after changes
 
 ### Validation
 
@@ -129,18 +131,18 @@ All tests pass. Backward compatible with templates that don't have TEMPLATE_TOOL
 
 ## Acceptance Criteria
 
-- [ ] `install_template_tools()` in `template-common.sh` handles single and multiple tool IDs
-- [ ] `read_template_info()` properly unsets `TEMPLATE_TOOLS` before and after sourcing (no leaking between templates)
-- [ ] `dev-template.sh` installs tools declared in `TEMPLATE_TOOLS`
-- [ ] `dev-template-ai.sh` installs tools declared in `TEMPLATE_TOOLS`
-- [ ] Tools added to `enabled-tools.conf` (persist across rebuilds)
-- [ ] Backward compatible -- templates without `TEMPLATE_TOOLS` work as before
-- [ ] Unknown tool IDs produce a warning, not a crash
-- [ ] Template details dialog shows required tools before user confirms
-- [ ] `--help` mentions automatic tool installation
-- [ ] Re-running on same project doesn't reinstall already-installed tools
-- [ ] Failed tool install doesn't abort template installer -- warns and continues
-- [ ] Cleanup runs even when tool installs fail
+- [x] `install_template_tools()` in `template-common.sh` handles single and multiple tool IDs
+- [x] `read_template_info()` properly unsets `TEMPLATE_TOOLS` before and after sourcing (no leaking between templates)
+- [x] `dev-template.sh` installs tools declared in `TEMPLATE_TOOLS`
+- [x] `dev-template-ai.sh` installs tools declared in `TEMPLATE_TOOLS`
+- [x] Tools added to `enabled-tools.conf` (persist across rebuilds)
+- [x] Backward compatible -- templates without `TEMPLATE_TOOLS` work as before
+- [x] Unknown tool IDs produce a warning, not a crash
+- [x] Template details dialog shows required tools before user confirms
+- [x] `--help` mentions automatic tool installation
+- [x] Re-running on same project doesn't reinstall already-installed tools
+- [x] Failed tool install doesn't abort template installer -- warns and continues
+- [x] Cleanup runs even when tool installs fail
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `TEMPLATE_README` field — completion message shows `cat {readme}` and `source ~/.bashrc`
- Rename `TEMPLATE_PURPOSE` → `TEMPLATE_ABSTRACT` (coordinated with dev-templates repo)
- Fix `((counter++))` crash with `set -e` — completion message was never shown
- Fix `TEMPLATE_NAME` variable collision — `read_template_info` unset wiped CLI argument
- Add `dev-template-ai` symlink to Dockerfile
- List available templates when invalid name given (both scripts)
- Add PHP install scripts investigation

## Test plan
- [x] `dev-template python-basic-webserver` — completion message shows with README and source instructions
- [x] `dev-template-ai plan-based-workflow` — completion message shows README, no source step
- [x] `dev-template jalla` — lists available templates with names
- [x] `dev-template-ai jalla` — lists available templates with names
- [x] Interactive menu works for both scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)